### PR TITLE
Add support for prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ https://github.com/user-attachments/assets/aa779b1c-a443-48d7-b3eb-13f27a4333b3
 
 ## Overview
 
-This extension provides a simplified, trait-based approach to exposing Jupyter functionality through the MCP protocol. It can dynamically load and register tools from various Python packages, making them available to AI assistants and other MCP clients.
+This extension provides a simplified, trait-based approach to exposing Jupyter functionality through the MCP protocol. It can dynamically load and register tools and prompts from various Python packages, making them available to AI assistants and other MCP clients.
 
 ## Key Features
 
 - **Simplified Architecture**: Direct function registration without complex abstractions
-- **Configurable Tool Loading**: Register tools via string specifications (`module:function`)
-- **Automatic Tool Discovery**: Python packages can expose tools via entrypoints
+- **Configurable Tool & Prompt Loading**: Register tools and prompts via string specifications (`module:function`)
+- **Automatic Discovery**: Python packages can expose tools and prompts via entrypoints
 - **Jupyter Integration**: Seamless integration with Jupyter Server extension system
 - **HTTP Transport**: FastMCP-based HTTP server with proper MCP protocol support
 - **Traitlets Configuration**: Full configuration support through Jupyter's traitlets system
@@ -42,14 +42,20 @@ c.MCPExtensionApp.mcp_tools = [
     "os:getcwd",
     "json:dumps",
     "time:time",
-    
-    # Jupyter AI Tools - Notebook operations  
+
+    # Jupyter AI Tools - Notebook operations
     "jupyter_ai_tools.toolkits.notebook:read_notebook",
     "jupyter_ai_tools.toolkits.notebook:edit_cell",
-    
+
     # JupyterLab Commands Toolkit
     "jupyterlab_commands_toolkit.tools:list_all_commands",
     "jupyterlab_commands_toolkit.tools:execute_command",
+]
+
+# Register prompts for code assistance
+c.MCPExtensionApp.mcp_prompts = [
+    "my_package.prompts:code_review_prompt",
+    "my_package.prompts:documentation_prompt",
 ]
 ```
 
@@ -121,9 +127,12 @@ await server.start_server()
 ```
 
 **Key Methods:**
-- `register_tool(func, name=None, description=None)` - Register a Python function
+- `register_tool(func, name=None, description=None)` - Register a Python function as a tool
 - `register_tools(tools)` - Register multiple functions (list or dict)
 - `list_tools()` - Get list of registered tools
+- `register_prompt(func, name=None, description=None)` - Register a Python function as a prompt
+- `register_prompts(prompts)` - Register multiple prompt functions (list or dict)
+- `list_prompts()` - Get list of registered prompts
 - `start_server(host=None)` - Start the HTTP MCP server
 
 #### MCPExtensionApp (`jupyter_server_mcp.extension.MCPExtensionApp`)
@@ -134,7 +143,8 @@ Jupyter Server extension that manages the MCP server lifecycle:
 - `mcp_name` - Server name (default: "Jupyter MCP Server")
 - `mcp_port` - Server port (default: 3001)
 - `mcp_tools` - List of tools to register (format: "module:function")
-- `use_tool_discovery` - Enable automatic tool discovery via entrypoints (default: True)
+- `mcp_prompts` - List of prompts to register (format: "module:function")
+- `use_tool_discovery` - Enable automatic discovery via entrypoints (default: True)
 
 ### Tool Registration
 
@@ -185,6 +195,95 @@ Tools from entrypoints are discovered automatically when the extension starts. T
 c.MCPExtensionApp.use_tool_discovery = False
 ```
 
+### Prompt Registration
+
+Prompts can be registered in two ways:
+
+#### 1. Manual Configuration
+
+Specify prompts directly in your Jupyter configuration using `module:function` format:
+
+```python
+c.MCPExtensionApp.mcp_prompts = [
+    "my_package.prompts:code_review_prompt",
+    "my_package.prompts:documentation_prompt",
+]
+```
+
+#### 2. Automatic Discovery via Entrypoints
+
+Python packages can expose prompts automatically using the `jupyter_server_mcp.prompts` entrypoint group.
+
+**In your package's `pyproject.toml`:**
+
+```toml
+[project.entry-points."jupyter_server_mcp.prompts"]
+my_package_prompts = "my_package.prompts:PROMPTS"
+```
+
+**In `my_package/prompts.py`:**
+
+```python
+# Option 1: Define as a list
+PROMPTS = [
+    "my_package.prompts:code_review_prompt",
+    "my_package.prompts:documentation_prompt",
+    "my_package.prompts:test_generation_prompt",
+]
+
+# Option 2: Define as a function
+def get_prompts():
+    return [
+        "my_package.prompts:code_review_prompt",
+        "my_package.prompts:documentation_prompt",
+    ]
+
+# Example prompt functions
+def code_review_prompt(file_path: str, focus_area: str = "general") -> str:
+    """Generate a code review prompt for a specific file.
+
+    Args:
+        file_path: Path to the file to review
+        focus_area: Aspect to focus on (e.g., 'security', 'performance', 'general')
+
+    Returns:
+        A formatted prompt for code review
+    """
+    return f"""Please review the code in {file_path} with a focus on {focus_area}.
+
+Provide feedback on:
+- Code quality and best practices
+- Potential bugs or issues
+- Performance considerations
+- Security concerns
+- Documentation and readability
+"""
+
+def documentation_prompt(module_name: str, target_audience: str = "developers") -> str:
+    """Generate a documentation prompt for a module.
+
+    Args:
+        module_name: Name of the module to document
+        target_audience: Who will read this (e.g., 'developers', 'users', 'contributors')
+
+    Returns:
+        A formatted prompt for documentation generation
+    """
+    return f"""Create comprehensive documentation for the {module_name} module.
+
+Target audience: {target_audience}
+
+Include:
+- Overview and purpose
+- Key features and capabilities
+- Usage examples with code
+- API reference
+- Common patterns and best practices
+"""
+```
+
+Prompts from entrypoints are discovered automatically when the extension starts, using the same `use_tool_discovery` setting as tools.
+
 ## Configuration Examples
 
 ### Minimal Setup
@@ -203,35 +302,49 @@ c.MCPExtensionApp.mcp_port = 8080
 c.MCPExtensionApp.mcp_tools = [
     # File system operations (jupyter-ai-tools)
     "jupyter_ai_tools.toolkits.file_system:read",
-    "jupyter_ai_tools.toolkits.file_system:write", 
+    "jupyter_ai_tools.toolkits.file_system:write",
     "jupyter_ai_tools.toolkits.file_system:edit",
     "jupyter_ai_tools.toolkits.file_system:ls",
     "jupyter_ai_tools.toolkits.file_system:glob",
-    
+
     # Notebook operations (jupyter-ai-tools)
     "jupyter_ai_tools.toolkits.notebook:read_notebook",
     "jupyter_ai_tools.toolkits.notebook:edit_cell",
-    "jupyter_ai_tools.toolkits.notebook:add_cell", 
+    "jupyter_ai_tools.toolkits.notebook:add_cell",
     "jupyter_ai_tools.toolkits.notebook:delete_cell",
     "jupyter_ai_tools.toolkits.notebook:create_notebook",
-    
+
     # Git operations (jupyter-ai-tools)
     "jupyter_ai_tools.toolkits.git:git_status",
     "jupyter_ai_tools.toolkits.git:git_add",
     "jupyter_ai_tools.toolkits.git:git_commit",
     "jupyter_ai_tools.toolkits.git:git_push",
-    
+
     # JupyterLab operations (jupyterlab-commands-toolkit)
     "jupyterlab_commands_toolkit.tools:clear_all_outputs_in_notebook",
     "jupyterlab_commands_toolkit.tools:open_document",
     "jupyterlab_commands_toolkit.tools:open_markdown_file_in_preview_mode",
     "jupyterlab_commands_toolkit.tools:show_diff_of_current_notebook",
-    
-    # Utility functions  
+
+    # Utility functions
     "os:getcwd",
     "json:dumps",
     "time:time",
     "platform:system",
+]
+
+c.MCPExtensionApp.mcp_prompts = [
+    # Code analysis prompts
+    "my_package.prompts:code_review_prompt",
+    "my_package.prompts:refactoring_suggestions_prompt",
+
+    # Documentation prompts
+    "my_package.prompts:documentation_prompt",
+    "my_package.prompts:api_documentation_prompt",
+
+    # Testing prompts
+    "my_package.prompts:test_generation_prompt",
+    "my_package.prompts:test_coverage_analysis_prompt",
 ]
 ```
 
@@ -258,17 +371,94 @@ jupyter_server_mcp/
 │   └── extension.py       # Jupyter Server extension
 ├── tests/
 │   ├── test_mcp_server.py # MCPServer tests
-│   └── test_extension.py  # Extension tests  
-├── demo/
-│   ├── jupyter_config.py  # Example configuration
-│   └── *.py              # Debug/diagnostic scripts
+│   └── test_extension.py  # Extension tests
 └── pyproject.toml         # Package configuration
 ```
+
+## Example: Creating a Package with Prompts
+
+Here's how to create a package that exposes prompts via entrypoints:
+
+**my_package/prompts.py:**
+```python
+"""Example prompt functions for code assistance."""
+
+def code_review_prompt(file_path: str, focus_area: str = "general") -> str:
+    """Generate a code review prompt for a specific file.
+
+    Args:
+        file_path: Path to the file to review
+        focus_area: Aspect to focus on (e.g., 'security', 'performance', 'general')
+
+    Returns:
+        A formatted prompt for code review
+    """
+    return f"""Please review the code in {file_path} with a focus on {focus_area}.
+
+Provide feedback on:
+- Code quality and best practices
+- Potential bugs or issues
+- Performance considerations
+- Security concerns
+- Documentation and readability
+"""
+
+def documentation_prompt(module_name: str, target_audience: str = "developers") -> str:
+    """Generate a documentation prompt for a module."""
+    return f"""Create comprehensive documentation for the {module_name} module.
+
+Target audience: {target_audience}
+
+Include:
+- Overview and purpose
+- Key features and capabilities
+- Usage examples with code
+- API reference
+- Common patterns and best practices
+"""
+
+def test_generation_prompt(function_name: str, function_code: str) -> str:
+    """Generate a prompt for creating unit tests."""
+    return f"""Generate comprehensive unit tests for the following function:
+
+Function name: {function_name}
+
+Code:
+```python
+{function_code}
+```
+
+Please create:
+- Test cases for normal operation
+- Edge cases and boundary conditions
+- Error handling tests
+- Mocking examples if needed
+"""
+
+# Define prompts list for entrypoint discovery
+PROMPTS = [
+    "my_package.prompts:code_review_prompt",
+    "my_package.prompts:documentation_prompt",
+    "my_package.prompts:test_generation_prompt",
+]
+```
+
+**pyproject.toml:**
+```toml
+[project]
+name = "my-package"
+version = "0.1.0"
+
+[project.entry-points."jupyter_server_mcp.prompts"]
+my_package_prompts = "my_package.prompts:PROMPTS"
+```
+
+After installing your package, the prompts will be automatically discovered and registered when the Jupyter Server MCP extension starts.
 
 ## Contributing
 
 1. Fork the repository
 2. Create a feature branch
-3. Add tests for new functionality  
+3. Add tests for new functionality
 4. Ensure all tests pass: `pytest tests/`
 5. Submit a pull request

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -254,7 +254,9 @@ class MCPExtensionApp(ExtensionApp):
                         continue
 
                     # Validate and collect prompt specs
-                    valid_specs = [spec for spec in prompt_specs if isinstance(spec, str)]
+                    valid_specs = [
+                        spec for spec in prompt_specs if isinstance(spec, str)
+                    ]
                     invalid_count = len(prompt_specs) - len(valid_specs)
 
                     if invalid_count > 0:

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -392,7 +392,9 @@ class MCPServer(LoggingConfigurable):
             for name, func in prompts.items():
                 self.register_prompt(func, name=name)
         else:
-            msg = "prompts must be a list of functions or dict mapping names to functions"
+            msg = (
+                "prompts must be a list of functions or dict mapping names to functions"
+            )
             raise ValueError(msg)
 
     def list_prompts(self) -> list[dict[str, Any]]:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -613,9 +613,7 @@ class TestEntrypointDiscovery:
                     "_discover_entrypoint_prompts",
                     return_value=discovered_prompts,
                 ),
-                patch.object(
-                    extension, "_discover_entrypoint_tools", return_value=[]
-                ),
+                patch.object(extension, "_discover_entrypoint_tools", return_value=[]),
             ):
                 await extension.start_extension()
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -72,7 +72,8 @@ class TestMCPExtensionLifecycle:
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
             mock_server.start_server = AsyncMock()
-            mock_server._registered_tools = []  # Use list instead of Mock
+            mock_server._registered_tools = {}
+            mock_server._registered_prompts = {}
             mock_mcp_class.return_value = mock_server
 
             await extension.start_extension()
@@ -163,7 +164,8 @@ class TestMCPExtensionLifecycle:
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
             mock_server.start_server = AsyncMock()
-            mock_server._registered_tools = []  # Use list instead of Mock
+            mock_server._registered_tools = {}
+            mock_server._registered_prompts = {}
             mock_mcp_class.return_value = mock_server
 
             # Start extension
@@ -323,8 +325,8 @@ class TestToolLoading:
         extension = MCPExtensionApp()
         extension.mcp_server_instance = Mock()
         extension.mcp_prompts = [
-            "package.prompts:code_review",
-            "package.prompts:documentation",
+            "os:getcwd",
+            "json:dumps",
         ]
 
         # Capture log output
@@ -336,6 +338,12 @@ class TestToolLoading:
 
             # Check log messages
             mock_logger.info.assert_any_call("Registering 2 prompts from configuration")
+            mock_logger.info.assert_any_call(
+                "✅ Registered prompt from configuration: os:getcwd"
+            )
+            mock_logger.info.assert_any_call(
+                "✅ Registered prompt from configuration: json:dumps"
+            )
 
     def test_register_configured_prompts_with_errors(self):
         """Test registering prompts when some fail to load."""
@@ -378,6 +386,7 @@ class TestExtensionWithTools:
                 "getcwd": {},
                 "sqrt": {},
             }  # Mock registered tools
+            mock_server._registered_prompts = {}
             mock_mcp_class.return_value = mock_server
 
             await extension.start_extension()
@@ -401,6 +410,7 @@ class TestExtensionWithTools:
             mock_server = Mock()
             mock_server.start_server = AsyncMock()
             mock_server._registered_tools = {}
+            mock_server._registered_prompts = {}
             mock_mcp_class.return_value = mock_server
 
             await extension.start_extension()
@@ -495,6 +505,7 @@ class TestEntrypointDiscovery:
             mock_server = Mock()
             mock_server.start_server = AsyncMock()
             mock_server._registered_tools = {"getcwd": {}, "dumps": {}}
+            mock_server._registered_prompts = {}
             mock_mcp_class.return_value = mock_server
 
             with patch.object(
@@ -593,17 +604,17 @@ class TestEntrypointDiscovery:
         extension = MCPExtensionApp()
         extension.mcp_port = 3087
         extension.use_tool_discovery = True
-        extension.mcp_prompts = ["package.prompts:config_prompt"]
+        extension.mcp_prompts = ["json:dumps"]
 
-        discovered_prompts = ["package.prompts:discovered_prompt"]
+        discovered_prompts = ["os:getcwd"]
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
             mock_server.start_server = AsyncMock()
             mock_server._registered_tools = {}
             mock_server._registered_prompts = {
-                "discovered_prompt": {},
-                "config_prompt": {},
+                "getcwd": {},
+                "dumps": {},
             }
             mock_mcp_class.return_value = mock_server
 
@@ -626,13 +637,13 @@ class TestEntrypointDiscovery:
         extension = MCPExtensionApp()
         extension.mcp_port = 3088
         extension.mcp_tools = ["os:getcwd"]
-        extension.mcp_prompts = ["package.prompts:review"]
+        extension.mcp_prompts = ["json:dumps"]
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
             mock_server.start_server = AsyncMock()
             mock_server._registered_tools = {"getcwd": {}}
-            mock_server._registered_prompts = {"review": {}}
+            mock_server._registered_prompts = {"dumps": {}}
             mock_mcp_class.return_value = mock_server
 
             with (

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -35,6 +35,16 @@ class TestMCPExtensionApp:
         extension.mcp_tools = ["os:getcwd", "math:sqrt"]
         assert extension.mcp_tools == ["os:getcwd", "math:sqrt"]
 
+        # Test prompts configuration
+        extension.mcp_prompts = [
+            "package.prompts:code_review",
+            "package.prompts:documentation",
+        ]
+        assert extension.mcp_prompts == [
+            "package.prompts:code_review",
+            "package.prompts:documentation",
+        ]
+
     def test_initialize_handlers(self):
         """Test handler initialization (should be no-op)."""
         extension = MCPExtensionApp()
@@ -298,6 +308,57 @@ class TestToolLoading:
                 "Could not import module 'invalid': No module named 'invalid'"
             )
 
+    def test_register_configured_prompts_empty(self):
+        """Test registering prompts when mcp_prompts is empty."""
+        extension = MCPExtensionApp()
+        extension.mcp_server_instance = Mock()
+        extension.mcp_prompts = []
+
+        # Should not call register_prompt
+        extension._register_prompts(extension.mcp_prompts, source="configuration")
+        extension.mcp_server_instance.register_prompt.assert_not_called()
+
+    def test_register_configured_prompts_valid(self):
+        """Test registering valid configured prompts."""
+        extension = MCPExtensionApp()
+        extension.mcp_server_instance = Mock()
+        extension.mcp_prompts = [
+            "package.prompts:code_review",
+            "package.prompts:documentation",
+        ]
+
+        # Capture log output
+        with patch("jupyter_server_mcp.extension.logger") as mock_logger:
+            extension._register_prompts(extension.mcp_prompts, source="configuration")
+
+            # Should register both prompts
+            assert extension.mcp_server_instance.register_prompt.call_count == 2
+
+            # Check log messages
+            mock_logger.info.assert_any_call("Registering 2 prompts from configuration")
+
+    def test_register_configured_prompts_with_errors(self):
+        """Test registering prompts when some fail to load."""
+        extension = MCPExtensionApp()
+        extension.mcp_server_instance = Mock()
+        extension.mcp_prompts = [
+            "os:getcwd",  # Valid import but might not be a good prompt
+            "invalid:function",
+            "json:dumps",
+        ]
+
+        with patch("jupyter_server_mcp.extension.logger") as mock_logger:
+            extension._register_prompts(extension.mcp_prompts, source="configuration")
+
+            # Should register 2 valid prompts (os:getcwd and json:dumps)
+            assert extension.mcp_server_instance.register_prompt.call_count == 2
+
+            # Check error logging for the invalid one
+            mock_logger.error.assert_any_call(
+                "❌ Failed to register prompt 'invalid:function' from configuration: "
+                "Could not import module 'invalid': No module named 'invalid'"
+            )
+
 
 class TestExtensionWithTools:
     """Test extension lifecycle with configured tools."""
@@ -443,3 +504,147 @@ class TestEntrypointDiscovery:
 
                 # Should register both entrypoint (1) and configured (1) tools = 2 total
                 assert mock_server.register_tool.call_count == 2
+
+    def test_discover_entrypoint_prompts_multiple_types(self):
+        """Test discovering prompts from both list and function entrypoints."""
+        extension = MCPExtensionApp()
+
+        # Create mock entrypoints - one list, one function
+        mock_ep1 = Mock()
+        mock_ep1.name = "package1_prompts"
+        mock_ep1.value = "package1.prompts:PROMPTS"
+        mock_ep1.load.return_value = [
+            "package1.prompts:code_review",
+            "package1.prompts:documentation",
+        ]
+
+        mock_ep2 = Mock()
+        mock_ep2.name = "package2_prompts"
+        mock_ep2.value = "package2.prompts:get_prompts"
+        mock_function = Mock(
+            return_value=[
+                "package2.prompts:test_gen",
+                "package2.prompts:refactor",
+            ]
+        )
+        mock_ep2.load.return_value = mock_function
+
+        with patch("importlib.metadata.entry_points") as mock_ep_func:
+            mock_ep_func.return_value.select = Mock(return_value=[mock_ep1, mock_ep2])
+
+            prompts = extension._discover_entrypoint_prompts()
+            assert len(prompts) == 4
+            assert set(prompts) == {
+                "package1.prompts:code_review",
+                "package1.prompts:documentation",
+                "package2.prompts:test_gen",
+                "package2.prompts:refactor",
+            }
+            mock_function.assert_called_once()  # Function was called
+
+    def test_discover_entrypoint_prompts_error_handling(self):
+        """Test that prompt discovery handles invalid entrypoints gracefully."""
+        extension = MCPExtensionApp()
+
+        # Mix of valid and invalid entrypoints
+        valid_ep = Mock()
+        valid_ep.name = "valid"
+        valid_ep.load.return_value = ["package.prompts:valid_prompt"]
+
+        invalid_type_ep = Mock()
+        invalid_type_ep.name = "invalid_type"
+        invalid_type_ep.load.return_value = "not_a_list"
+
+        function_bad_return_ep = Mock()
+        function_bad_return_ep.name = "bad_function"
+        function_bad_return_ep.load.return_value = Mock(return_value={"not": "list"})
+
+        load_error_ep = Mock()
+        load_error_ep.name = "load_error"
+        load_error_ep.load.side_effect = ImportError("Module not found")
+
+        with patch("importlib.metadata.entry_points") as mock_ep_func:
+            mock_ep_func.return_value.select = Mock(
+                return_value=[
+                    valid_ep,
+                    invalid_type_ep,
+                    function_bad_return_ep,
+                    load_error_ep,
+                ]
+            )
+
+            with patch("jupyter_server_mcp.extension.logger"):
+                prompts = extension._discover_entrypoint_prompts()
+                # Should only get the valid one
+                assert prompts == ["package.prompts:valid_prompt"]
+
+    def test_discover_entrypoint_prompts_disabled(self):
+        """Test that prompt discovery returns empty list when disabled."""
+        extension = MCPExtensionApp()
+        extension.use_tool_discovery = False
+
+        # Should return empty without trying to discover
+        prompts = extension._discover_entrypoint_prompts()
+        assert prompts == []
+
+    @pytest.mark.asyncio
+    async def test_start_extension_with_prompts_entrypoints_and_config(self):
+        """Test extension startup with both entrypoint and configured prompts."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3087
+        extension.use_tool_discovery = True
+        extension.mcp_prompts = ["package.prompts:config_prompt"]
+
+        discovered_prompts = ["package.prompts:discovered_prompt"]
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = Mock()
+            mock_server.start_server = AsyncMock()
+            mock_server._registered_tools = {}
+            mock_server._registered_prompts = {
+                "discovered_prompt": {},
+                "config_prompt": {},
+            }
+            mock_mcp_class.return_value = mock_server
+
+            with (
+                patch.object(
+                    extension,
+                    "_discover_entrypoint_prompts",
+                    return_value=discovered_prompts,
+                ),
+                patch.object(
+                    extension, "_discover_entrypoint_tools", return_value=[]
+                ),
+            ):
+                await extension.start_extension()
+
+                # Should register both entrypoint (1) and configured (1) prompts = 2 total
+                assert mock_server.register_prompt.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_start_extension_with_tools_and_prompts(self):
+        """Test extension startup with both tools and prompts."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3088
+        extension.mcp_tools = ["os:getcwd"]
+        extension.mcp_prompts = ["package.prompts:review"]
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = Mock()
+            mock_server.start_server = AsyncMock()
+            mock_server._registered_tools = {"getcwd": {}}
+            mock_server._registered_prompts = {"review": {}}
+            mock_mcp_class.return_value = mock_server
+
+            with (
+                patch.object(extension, "_discover_entrypoint_tools", return_value=[]),
+                patch.object(
+                    extension, "_discover_entrypoint_prompts", return_value=[]
+                ),
+            ):
+                await extension.start_extension()
+
+                # Should register 1 tool and 1 prompt
+                assert mock_server.register_tool.call_count == 1
+                assert mock_server.register_prompt.call_count == 1


### PR DESCRIPTION
Fixes #7 

Reference: https://modelcontextprotocol.io/specification/2025-06-18/server/prompts

- [x] Follow the approach currently used for tools
- [x] Support `jupyter_server_mcp.prompts` entrypoints