### PR TITLE
Improve handling of the MCP server port and shutdown behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ c = get_config()
 # Basic MCP server settings
 c.MCPExtensionApp.mcp_name = "My Jupyter MCP Server"
 
-# Optional: override the default MCP port (3001)
+# Optional: override the default MCP port (3001).
+# If 3001 is already in use, choose another fixed port and use the same
+# port in your MCP client configuration below.
 # c.MCPExtensionApp.mcp_port = 8080
 
 # Register tools from existing packages
@@ -87,6 +89,9 @@ jupyter lab --config=jupyter_config.py
 ```
 
 The MCP server will start automatically on `http://localhost:3001/mcp` by default.
+If the configured port is already in use, startup fails with a clear error instead
+of silently choosing another port, because MCP clients need to be configured with
+the actual endpoint URL.
 
 Any trait can also be set directly on the command line, without a config file. For example, to override the port:
 
@@ -293,6 +298,7 @@ c.MCPExtensionApp.use_tool_discovery = False
 c = get_config()
 
 # Optional: override the default port (3001)
+# Use a fixed port that matches your MCP client configuration.
 # c.MCPExtensionApp.mcp_port = 8080
 ```
 

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -189,6 +189,17 @@ class MCPExtensionApp(ExtensionApp):
         """Initialize settings for the extension."""
         # Configuration is handled by traitlets
 
+    async def _confirm_mcp_server_started(self):
+        """Raise if the background MCP server task failed during startup."""
+        await asyncio.sleep(0.5)
+
+        if self.mcp_server_task is None or not self.mcp_server_task.done():
+            return
+
+        await self.mcp_server_task
+        msg = "MCP server exited during startup"
+        raise RuntimeError(msg)
+
     async def start_extension(self):
         """Start the extension - called after Jupyter Server starts."""
         try:
@@ -210,14 +221,20 @@ class MCPExtensionApp(ExtensionApp):
                 self.mcp_server_instance.start_server()
             )
 
-            # Give the server a moment to start
-            await asyncio.sleep(0.5)
+            await self._confirm_mcp_server_started()
 
             registered_count = len(self.mcp_server_instance._registered_tools)
             self.log.info(f"✅ MCP server started on port {self.mcp_port}")
             self.log.info(f"Total registered tools: {registered_count}")
 
         except Exception as e:
+            if self.mcp_server_task and not self.mcp_server_task.done():
+                self.mcp_server_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self.mcp_server_task
+
+            self.mcp_server_task = None
+            self.mcp_server_instance = None
             self.log.error(f"Failed to start MCP server: {e}")
             raise
 

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import importlib
 import importlib.metadata
+import inspect
 import logging
 
 from jupyter_server.extension.application import ExtensionApp
@@ -192,12 +193,17 @@ class MCPExtensionApp(ExtensionApp):
 
     async def _confirm_mcp_server_started(self):
         """Raise if the background MCP server task failed during startup."""
-        await asyncio.sleep(0.5)
-
-        if self.mcp_server_task is None or not self.mcp_server_task.done():
+        task = self.mcp_server_task
+        if task is None:
             return
 
-        await self.mcp_server_task
+        done, _ = await asyncio.wait(
+            {task}, timeout=0.5, return_when=asyncio.FIRST_COMPLETED
+        )
+        if not done:
+            return
+
+        await task
         msg = "MCP server exited during startup"
         raise RuntimeError(msg)
 
@@ -209,9 +215,9 @@ class MCPExtensionApp(ExtensionApp):
         self.log.info("Stopping MCP server")
 
         instance = self.mcp_server_instance
-        supports_graceful = getattr(instance, "supports_graceful_stop", False) is True
-        if supports_graceful and isinstance(instance, MCPServer):
-            await instance.stop_server()
+        stop_server = getattr(instance, "stop_server", None)
+        if inspect.iscoroutinefunction(stop_server):
+            await stop_server()
             try:
                 await asyncio.wait_for(
                     asyncio.shield(self.mcp_server_task),

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -49,6 +49,7 @@ class MCPExtensionApp(ExtensionApp):
 
     mcp_server_instance: object | None = None
     mcp_server_task: asyncio.Task | None = None
+    mcp_shutdown_timeout = 5
 
     def _load_function_from_string(self, tool_spec: str):
         """Load a function from a string specification.
@@ -200,6 +201,30 @@ class MCPExtensionApp(ExtensionApp):
         msg = "MCP server exited during startup"
         raise RuntimeError(msg)
 
+    async def _stop_mcp_server_task(self):
+        """Stop the MCP server through its own shutdown path, then fall back."""
+        if self.mcp_server_task is None or self.mcp_server_task.done():
+            return
+
+        self.log.info("Stopping MCP server")
+
+        instance = self.mcp_server_instance
+        supports_graceful = getattr(instance, "supports_graceful_stop", False) is True
+        if supports_graceful and isinstance(instance, MCPServer):
+            await instance.stop_server()
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(self.mcp_server_task),
+                    timeout=self.mcp_shutdown_timeout,
+                )
+                return
+            except TimeoutError:
+                self.log.warning("Timed out waiting for MCP server to stop")
+
+        self.mcp_server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self.mcp_server_task
+
     async def start_extension(self):
         """Start the extension - called after Jupyter Server starts."""
         try:
@@ -244,13 +269,9 @@ class MCPExtensionApp(ExtensionApp):
 
     async def stop_extension(self):
         """Stop the extension - called when Jupyter Server shuts down."""
-        if self.mcp_server_task and not self.mcp_server_task.done():
-            self.log.info("Stopping MCP server")
-            self.mcp_server_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self.mcp_server_task
-
-        # Always clean up
-        self.mcp_server_task = None
-        self.mcp_server_instance = None
+        try:
+            await self._stop_mcp_server_task()
+        finally:
+            self.mcp_server_task = None
+            self.mcp_server_instance = None
         self.log.info("MCP server stopped")

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -16,8 +16,8 @@ from typing import Any, Union, get_args, get_origin
 
 import uvicorn
 from fastmcp import FastMCP
+from fastmcp import settings as fastmcp_settings
 from fastmcp.utilities.cli import log_server_banner
-from fastmcp.utilities.logging import temporary_log_level
 from traitlets import Int, Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
@@ -60,6 +60,8 @@ def _ensure_port_available(host: str, port: int) -> None:
             try:
                 if reuse_address:
                     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+                if family == socket.AF_INET6 and hasattr(socket, "IPPROTO_IPV6"):
+                    sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, True)
                 sock.bind(sockaddr)
                 checked_any_address = True
             except OSError as exc:
@@ -233,85 +235,8 @@ def _wrap_with_json_conversion(func: Callable) -> Callable:
     return sync_wrapper
 
 
-def _update_schema_for_json_args(func: Callable, tool) -> None:
-    """
-    Modify the tool's JSON schema to accept strings for dict parameters.
-
-    This function updates the input schema to allow JSON strings in addition to objects for
-    parameters that are annotated as dict types, enabling MCP clients to pass JSON strings
-    that will be automatically converted to dicts.
-
-    This modification is always applied to ensure compatibility with various MCP clients.
-
-    Args:
-        func: The original function
-        tool: The FastMCP tool object
-    """
-    try:
-        sig = signature(func)
-
-        # Get the MCP tool representation to modify its schema
-        mcp_tool_dict = tool.to_mcp_tool().model_dump()
-        input_schema = mcp_tool_dict.get("inputSchema", {})
-        properties = input_schema.get("properties", {})
-
-        # Check each parameter in the function signature
-        for param_name, param in sig.parameters.items():
-            if param_name in properties:
-                param_schema = properties[param_name]
-
-                # Check if this parameter should support JSON string conversion
-                annotation = param.annotation
-                should_support_string = _is_dict_compatible_annotation(annotation)
-
-                if should_support_string:
-                    # Modify the schema to also accept strings
-                    if "anyOf" in param_schema:
-                        # For Optional[dict] - add string to the anyOf list
-                        existing_schemas = param_schema["anyOf"]
-                        # Check if string is already in the schema
-                        has_string = any(
-                            s.get("type") == "string" for s in existing_schemas
-                        )
-                        if not has_string:
-                            existing_schemas.append(
-                                {
-                                    "type": "string",
-                                    "description": "JSON string that will be parsed to object",
-                                }
-                            )
-                    elif param_schema.get("type") == "object":
-                        # For dict - convert to anyOf with object and string
-                        original_schema = param_schema.copy()
-                        properties[param_name] = {
-                            "anyOf": [
-                                original_schema,
-                                {
-                                    "type": "string",
-                                    "description": "JSON string that will be parsed to object",
-                                },
-                            ],
-                            "title": param_schema.get("title", param_name.title()),
-                        }
-                        # Preserve default if it exists
-                        if "default" in param_schema:
-                            properties[param_name]["default"] = param_schema["default"]
-
-        # Update the tool's parameters with the modified schema
-        tool.parameters = input_schema
-
-        logger.debug(
-            f"Modified schema for tool '{tool.name}' to support JSON strings for dict parameters"
-        )
-
-    except Exception as e:
-        logger.warning(f"Could not modify schema for JSON string support: {e}")
-
-
 class MCPServer(LoggingConfigurable):
     """Simple MCP server that allows registering Python functions as tools."""
-
-    supports_graceful_stop = True
 
     # Configurable traits
     name = Unicode(
@@ -369,15 +294,7 @@ class MCPServer(LoggingConfigurable):
         registered_func = _wrap_with_json_conversion(func)
         self.log.debug(f"Applied JSON argument auto-conversion wrapper to {tool_name}")
 
-        # Register with FastMCP
-        tool = self.mcp.tool(registered_func)
-
-        # Modify schema to support JSON strings for dict parameters
-        if tool:
-            _update_schema_for_json_args(func, tool)
-            self.log.debug(
-                f"Modified schema for tool '{tool_name}' to accept JSON strings for dict parameters"
-            )
+        self.mcp.tool(registered_func)
 
         # Keep track for listing
         self._registered_tools[tool_name] = {
@@ -414,61 +331,41 @@ class MCPServer(LoggingConfigurable):
         """Get information about a specific tool."""
         return self._registered_tools.get(tool_name)
 
-    async def _run_http_async_without_signals(
-        self,
-        host: str,
-        port: int,
-        show_banner: bool = True,
-    ) -> None:
+    async def _run_http_async_without_signals(self, host: str, port: int) -> None:
         """Run FastMCP over HTTP without taking over process signal handlers."""
         transport = "http"
-        default_log_level = self.mcp._deprecated_settings.log_level.lower()
-
         app = self.mcp.http_app(transport=transport)
-        server_path = (
-            app.state.path.lstrip("/")
-            if hasattr(app, "state") and hasattr(app.state, "path")
-            else ""
+
+        log_server_banner(server=self.mcp)
+
+        config = uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            timeout_graceful_shutdown=2,
+            lifespan="on",
+            ws="websockets-sansio",
+            log_level=fastmcp_settings.log_level.lower(),
+        )
+        server = _EmbeddedUvicornServer(config)
+        self._uvicorn_server = server
+        path = getattr(app.state, "path", "").lstrip("/")
+        self.log.info(
+            f"Starting MCP server {self.name!r} with transport "
+            f"{transport!r} on http://{host}:{port}/{path}"
         )
 
-        if show_banner:
-            log_server_banner(
-                server=self.mcp,
-                transport=transport,
-                host=host,
-                port=port,
-                path=server_path,
-            )
-
-        config_kwargs: dict[str, Any] = {
-            "timeout_graceful_shutdown": 1,
-            "lifespan": "on",
-            "ws": "websockets-sansio",
-            "log_level": default_log_level,
-        }
-
-        with temporary_log_level(None):
-            async with self.mcp._lifespan_manager():
-                config = uvicorn.Config(app, host=host, port=port, **config_kwargs)
-                server = _EmbeddedUvicornServer(config)
-                self._uvicorn_server = server
-                path = getattr(app.state, "path", "").lstrip("/")
-                self.log.info(
-                    f"Starting MCP server {self.name!r} with transport "
-                    f"{transport!r} on http://{host}:{port}/{path}"
-                )
-
-                try:
-                    await server.serve()
-                except asyncio.CancelledError:
-                    server.should_exit = True
-                    if getattr(server, "started", False):
-                        with contextlib.suppress(Exception, asyncio.CancelledError):
-                            await server.shutdown()
-                    raise
-                finally:
-                    if self._uvicorn_server is server:
-                        self._uvicorn_server = None
+        try:
+            await server.serve()
+        except asyncio.CancelledError:
+            server.should_exit = True
+            if getattr(server, "started", False):
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await server.shutdown()
+            raise
+        finally:
+            if self._uvicorn_server is server:
+                self._uvicorn_server = None
 
     async def stop_server(self) -> None:
         """Request a graceful MCP HTTP server shutdown."""
@@ -480,9 +377,6 @@ class MCPServer(LoggingConfigurable):
         server_host = host or self.host
         _ensure_port_available(server_host, self.port)
 
-        self.log.info(f"Starting MCP server '{self.name}' on {server_host}:{self.port}")
         self.log.info(f"Registered tools: {list(self._registered_tools.keys())}")
-        self.log.debug(f"Server configuration - Host: {server_host}, Port: {self.port}")
 
-        # Start FastMCP server with HTTP transport
         await self._run_http_async_without_signals(host=server_host, port=self.port)

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -3,6 +3,7 @@
 import inspect
 import json
 import logging
+import socket
 from collections.abc import Callable
 from functools import wraps
 from inspect import iscoroutinefunction, signature
@@ -13,6 +14,31 @@ from traitlets import Int, Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
 logger = logging.getLogger(__name__)
+
+
+class MCPServerPortError(RuntimeError):
+    """Raised when the configured MCP server port cannot be bound."""
+
+
+def _ensure_port_available(host: str, port: int) -> None:
+    """Check whether Uvicorn will be able to bind to the configured address."""
+    if port == 0:
+        return
+
+    family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
+
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, port))
+    except OSError as exc:
+        msg = (
+            f"Cannot start MCP server on {host}:{port}: {exc.strerror or exc}. "
+            "Configure another MCP port with "
+            "c.MCPExtensionApp.mcp_port = <port> or "
+            "--MCPExtensionApp.mcp_port=<port>."
+        )
+        raise MCPServerPortError(msg) from exc
 
 
 def _is_dict_compatible_annotation(annotation) -> bool:
@@ -347,6 +373,7 @@ class MCPServer(LoggingConfigurable):
     async def start_server(self, host: str | None = None):
         """Start the MCP server on the specified host and port."""
         server_host = host or self.host
+        _ensure_port_available(server_host, self.port)
 
         self.log.info(f"Starting MCP server '{self.name}' on {server_host}:{self.port}")
         self.log.info(f"Registered tools: {list(self._registered_tools.keys())}")

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -1,5 +1,7 @@
 """Simple MCP server for registering Python functions as tools."""
 
+import asyncio
+import contextlib
 import inspect
 import json
 import logging
@@ -9,7 +11,10 @@ from functools import wraps
 from inspect import iscoroutinefunction, signature
 from typing import Any, Union, get_args, get_origin
 
+import uvicorn
 from fastmcp import FastMCP
+from fastmcp.utilities.cli import log_server_banner
+from fastmcp.utilities.logging import temporary_log_level
 from traitlets import Int, Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
@@ -18,6 +23,15 @@ logger = logging.getLogger(__name__)
 
 class MCPServerPortError(RuntimeError):
     """Raised when the configured MCP server port cannot be bound."""
+
+
+class _EmbeddedUvicornServer(uvicorn.Server):
+    """Uvicorn server variant that leaves process signals to Jupyter Server."""
+
+    @contextlib.contextmanager
+    def capture_signals(self):
+        """Do not install SIGINT/SIGTERM handlers for embedded servers."""
+        yield
 
 
 def _ensure_port_available(host: str, port: int) -> None:
@@ -270,6 +284,8 @@ def _update_schema_for_json_args(func: Callable, tool) -> None:
 class MCPServer(LoggingConfigurable):
     """Simple MCP server that allows registering Python functions as tools."""
 
+    supports_graceful_stop = True
+
     # Configurable traits
     name = Unicode(
         default_value="Jupyter MCP Server", help="Name for the MCP server"
@@ -294,6 +310,7 @@ class MCPServer(LoggingConfigurable):
         # Initialize FastMCP and tools registry
         self.mcp = FastMCP(self.name)
         self._registered_tools = {}
+        self._uvicorn_server: uvicorn.Server | None = None
         self.log.info(
             f"Initialized MCP server '{self.name}' on {self.host}:{self.port}"
         )
@@ -370,6 +387,67 @@ class MCPServer(LoggingConfigurable):
         """Get information about a specific tool."""
         return self._registered_tools.get(tool_name)
 
+    async def _run_http_async_without_signals(
+        self,
+        host: str,
+        port: int,
+        show_banner: bool = True,
+    ) -> None:
+        """Run FastMCP over HTTP without taking over process signal handlers."""
+        transport = "http"
+        default_log_level = self.mcp._deprecated_settings.log_level.lower()
+
+        app = self.mcp.http_app(transport=transport)
+        server_path = (
+            app.state.path.lstrip("/")
+            if hasattr(app, "state") and hasattr(app.state, "path")
+            else ""
+        )
+
+        if show_banner:
+            log_server_banner(
+                server=self.mcp,
+                transport=transport,
+                host=host,
+                port=port,
+                path=server_path,
+            )
+
+        config_kwargs: dict[str, Any] = {
+            "timeout_graceful_shutdown": 1,
+            "lifespan": "on",
+            "ws": "websockets-sansio",
+            "log_level": default_log_level,
+        }
+
+        with temporary_log_level(None):
+            async with self.mcp._lifespan_manager():
+                config = uvicorn.Config(app, host=host, port=port, **config_kwargs)
+                server = _EmbeddedUvicornServer(config)
+                self._uvicorn_server = server
+                path = getattr(app.state, "path", "").lstrip("/")
+                self.log.info(
+                    f"Starting MCP server {self.name!r} with transport "
+                    f"{transport!r} on http://{host}:{port}/{path}"
+                )
+
+                try:
+                    await server.serve()
+                except asyncio.CancelledError:
+                    server.should_exit = True
+                    if getattr(server, "started", False):
+                        with contextlib.suppress(Exception, asyncio.CancelledError):
+                            await server.shutdown()
+                    raise
+                finally:
+                    if self._uvicorn_server is server:
+                        self._uvicorn_server = None
+
+    async def stop_server(self) -> None:
+        """Request a graceful MCP HTTP server shutdown."""
+        if self._uvicorn_server is not None:
+            self._uvicorn_server.should_exit = True
+
     async def start_server(self, host: str | None = None):
         """Start the MCP server on the specified host and port."""
         server_host = host or self.host
@@ -380,4 +458,4 @@ class MCPServer(LoggingConfigurable):
         self.log.debug(f"Server configuration - Host: {server_host}, Port: {self.port}")
 
         # Start FastMCP server with HTTP transport
-        await self.mcp.run_http_async(host=server_host, port=self.port)
+        await self._run_http_async_without_signals(host=server_host, port=self.port)

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -2,10 +2,13 @@
 
 import asyncio
 import contextlib
+import errno
 import inspect
 import json
 import logging
+import os
 import socket
+import sys
 from collections.abc import Callable
 from functools import wraps
 from inspect import iscoroutinefunction, signature
@@ -39,12 +42,36 @@ def _ensure_port_available(host: str, port: int) -> None:
     if port == 0:
         return
 
-    family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
-
     try:
-        with socket.socket(family, socket.SOCK_STREAM) as sock:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind((host, port))
+        addr_infos = socket.getaddrinfo(
+            host or None,
+            port,
+            type=socket.SOCK_STREAM,
+            flags=socket.AI_PASSIVE,
+        )
+        reuse_address = os.name == "posix" and sys.platform != "cygwin"
+        checked_any_address = False
+        for family, socktype, proto, _canonname, sockaddr in set(addr_infos):
+            try:
+                sock = socket.socket(family, socktype, proto)
+            except OSError:
+                continue
+
+            try:
+                if reuse_address:
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+                sock.bind(sockaddr)
+                checked_any_address = True
+            except OSError as exc:
+                if exc.errno == errno.EADDRNOTAVAIL:
+                    continue
+                raise
+            finally:
+                sock.close()
+
+        if not checked_any_address:
+            msg = f"could not bind on any address from {addr_infos}"
+            raise OSError(msg)
     except OSError as exc:
         msg = (
             f"Cannot start MCP server on {host}:{port}: {exc.strerror or exc}. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
     "jupyter_server>=1.6,<3",
-    "fastmcp>=2.0.0"
+    "fastmcp>=3.2.4"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -8,6 +8,11 @@ import pytest
 from jupyter_server_mcp.extension import MCPExtensionApp
 
 
+async def _run_until_cancelled():
+    """Keep mocked server tasks alive until the extension stops them."""
+    await asyncio.Future()
+
+
 class TestMCPExtensionApp:
     """Test MCPExtensionApp functionality."""
 
@@ -61,7 +66,7 @@ class TestMCPExtensionLifecycle:
         # Mock the MCP server creation to avoid actual server startup
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
-            mock_server.start_server = AsyncMock()
+            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
             mock_server._registered_tools = []  # Use list instead of Mock
             mock_mcp_class.return_value = mock_server
 
@@ -79,6 +84,8 @@ class TestMCPExtensionLifecycle:
             assert extension.mcp_server_instance == mock_server
             assert extension.mcp_server_task is not None
 
+            await extension.stop_extension()
+
     @pytest.mark.asyncio
     async def test_start_extension_failure(self):
         """Test extension startup failure handling."""
@@ -90,6 +97,28 @@ class TestMCPExtensionLifecycle:
 
             with pytest.raises(Exception, match="Server creation failed"):
                 await extension.start_extension()
+
+            assert extension.mcp_server_instance is None
+            assert extension.mcp_server_task is None
+
+    @pytest.mark.asyncio
+    async def test_start_extension_detects_server_task_failure(self):
+        """Test startup failure from the background MCP server task."""
+        extension = MCPExtensionApp()
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = Mock()
+            mock_server.start_server = AsyncMock(
+                side_effect=RuntimeError("Port 3001 is already in use")
+            )
+            mock_server._registered_tools = []
+            mock_mcp_class.return_value = mock_server
+
+            with pytest.raises(RuntimeError, match="Port 3001 is already in use"):
+                await extension.start_extension()
+
+            assert extension.mcp_server_instance is None
+            assert extension.mcp_server_task is None
 
     @pytest.mark.asyncio
     async def test_stop_extension_with_running_server(self):
@@ -152,7 +181,7 @@ class TestMCPExtensionLifecycle:
         # Mock the MCP server
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
-            mock_server.start_server = AsyncMock()
+            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
             mock_server._registered_tools = []  # Use list instead of Mock
             mock_mcp_class.return_value = mock_server
 
@@ -312,7 +341,7 @@ class TestExtensionWithTools:
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
-            mock_server.start_server = AsyncMock()
+            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
             mock_server._registered_tools = {
                 "getcwd": {},
                 "sqrt": {},
@@ -329,6 +358,8 @@ class TestExtensionWithTools:
             # Verify tools were registered
             assert mock_server.register_tool.call_count == 2
 
+            await extension.stop_extension()
+
     @pytest.mark.asyncio
     async def test_start_extension_no_tools(self):
         """Test extension startup with no configured tools."""
@@ -338,7 +369,7 @@ class TestExtensionWithTools:
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
-            mock_server.start_server = AsyncMock()
+            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
             mock_server._registered_tools = {}
             mock_mcp_class.return_value = mock_server
 
@@ -346,6 +377,8 @@ class TestExtensionWithTools:
 
             # Should not register any tools
             mock_server.register_tool.assert_not_called()
+
+            await extension.stop_extension()
 
 
 class TestEntrypointDiscovery:
@@ -432,7 +465,7 @@ class TestEntrypointDiscovery:
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = Mock()
-            mock_server.start_server = AsyncMock()
+            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
             mock_server._registered_tools = {"getcwd": {}, "dumps": {}}
             mock_mcp_class.return_value = mock_server
 
@@ -443,3 +476,5 @@ class TestEntrypointDiscovery:
 
                 # Should register both entrypoint (1) and configured (1) tools = 2 total
                 assert mock_server.register_tool.call_count == 2
+
+                await extension.stop_extension()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -14,6 +14,14 @@ async def _run_until_cancelled():
     await asyncio.Future()
 
 
+def _mock_running_server(registered_tools=None):
+    """Create an MCP server mock whose start task stays alive."""
+    mock_server = Mock()
+    mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
+    mock_server._registered_tools = [] if registered_tools is None else registered_tools
+    return mock_server
+
+
 class TestMCPExtensionApp:
     """Test MCPExtensionApp functionality."""
 
@@ -66,10 +74,9 @@ class TestMCPExtensionLifecycle:
 
         # Mock the MCP server creation to avoid actual server startup
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
-            mock_server = Mock()
-            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
-            mock_server._registered_tools = []  # Use list instead of Mock
+            mock_server = _mock_running_server()
             mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
 
             await extension.start_extension()
 
@@ -84,6 +91,7 @@ class TestMCPExtensionLifecycle:
             # Verify extension state
             assert extension.mcp_server_instance == mock_server
             assert extension.mcp_server_task is not None
+            extension._confirm_mcp_server_started.assert_awaited_once()
 
             await extension.stop_extension()
 
@@ -208,10 +216,9 @@ class TestMCPExtensionLifecycle:
 
         # Mock the MCP server
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
-            mock_server = Mock()
-            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
-            mock_server._registered_tools = []  # Use list instead of Mock
+            mock_server = _mock_running_server()
             mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
 
             # Start extension
             await extension.start_extension()
@@ -232,6 +239,7 @@ class TestMCPExtensionLifecycle:
             # Task should be either cancelled or done (in mock scenarios,
             # it might finish before cancellation)
             assert original_task.cancelled() or original_task.done()
+            extension._confirm_mcp_server_started.assert_awaited_once()
 
 
 class TestExtensionIntegration:
@@ -368,13 +376,9 @@ class TestExtensionWithTools:
         extension.mcp_tools = ["os:getcwd", "math:sqrt"]
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
-            mock_server = Mock()
-            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
-            mock_server._registered_tools = {
-                "getcwd": {},
-                "sqrt": {},
-            }  # Mock registered tools
+            mock_server = _mock_running_server({"getcwd": {}, "sqrt": {}})
             mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
 
             await extension.start_extension()
 
@@ -385,6 +389,7 @@ class TestExtensionWithTools:
 
             # Verify tools were registered
             assert mock_server.register_tool.call_count == 2
+            extension._confirm_mcp_server_started.assert_awaited_once()
 
             await extension.stop_extension()
 
@@ -396,15 +401,15 @@ class TestExtensionWithTools:
         extension.mcp_tools = []
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
-            mock_server = Mock()
-            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
-            mock_server._registered_tools = {}
+            mock_server = _mock_running_server({})
             mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
 
             await extension.start_extension()
 
             # Should not register any tools
             mock_server.register_tool.assert_not_called()
+            extension._confirm_mcp_server_started.assert_awaited_once()
 
             await extension.stop_extension()
 
@@ -492,10 +497,9 @@ class TestEntrypointDiscovery:
         discovered_tools = ["os:getcwd"]
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
-            mock_server = Mock()
-            mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
-            mock_server._registered_tools = {"getcwd": {}, "dumps": {}}
+            mock_server = _mock_running_server({"getcwd": {}, "dumps": {}})
             mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
 
             with patch.object(
                 extension, "_discover_entrypoint_tools", return_value=discovered_tools
@@ -504,5 +508,6 @@ class TestEntrypointDiscovery:
 
                 # Should register both entrypoint (1) and configured (1) tools = 2 total
                 assert mock_server.register_tool.call_count == 2
+                extension._confirm_mcp_server_started.assert_awaited_once()
 
                 await extension.stop_extension()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from jupyter_server_mcp.extension import MCPExtensionApp
+from jupyter_server_mcp.mcp_server import MCPServer
 
 
 async def _run_until_cancelled():
@@ -139,6 +140,33 @@ class TestMCPExtensionLifecycle:
 
         # Verify cleanup
         assert task.cancelled()
+        assert extension.mcp_server_task is None
+        assert extension.mcp_server_instance is None
+
+    @pytest.mark.asyncio
+    async def test_stop_extension_uses_mcp_server_shutdown(self):
+        """Test stopping extension through the MCP server shutdown hook."""
+        extension = MCPExtensionApp()
+        stop_event = asyncio.Event()
+
+        async def dummy_task():
+            await stop_event.wait()
+
+        async def stop_server():
+            stop_event.set()
+
+        task = asyncio.create_task(dummy_task())
+        server = MCPServer()
+        server.stop_server = AsyncMock(side_effect=stop_server)
+
+        extension.mcp_server_task = task
+        extension.mcp_server_instance = server
+
+        await extension.stop_extension()
+
+        server.stop_server.assert_called_once()
+        assert task.done()
+        assert not task.cancelled()
         assert extension.mcp_server_task is None
         assert extension.mcp_server_instance is None
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -292,13 +292,13 @@ class TestMCPServer:
             }
             return [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0))]
 
+        def fake_socket(family, socktype, proto):
+            return FailingSocket(family, socktype, proto)
+
         monkeypatch.setattr(
             "jupyter_server_mcp.mcp_server.socket.getaddrinfo", fake_getaddrinfo
         )
-        monkeypatch.setattr(
-            "jupyter_server_mcp.mcp_server.socket.socket",
-            lambda family, socktype, proto: FailingSocket(family, socktype, proto),
-        )
+        monkeypatch.setattr("jupyter_server_mcp.mcp_server.socket.socket", fake_socket)
 
         with pytest.raises(MCPServerPortError, match="Cannot start MCP server"):
             _ensure_port_available("localhost", 3001)
@@ -310,7 +310,9 @@ class TestMCPServer:
         class PartiallyFailingSocket(FakeSocket):
             def bind(self, sockaddr):
                 if self.family == socket.AF_INET6:
-                    raise OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+                    raise OSError(
+                        errno.EADDRNOTAVAIL, "Cannot assign requested address"
+                    )
                 super().bind(sockaddr)
 
         def fake_getaddrinfo(host, port, **kwargs):
@@ -336,9 +338,7 @@ class TestMCPServer:
 
         _ensure_port_available("localhost", 3001)
 
-        assert ("127.0.0.1", 3001) in {
-            sock.bound_address for sock in created_sockets
-        }
+        assert ("127.0.0.1", 3001) in {sock.bound_address for sock in created_sockets}
 
     @pytest.mark.asyncio
     async def test_start_server_checks_port_before_uvicorn(self, monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,13 +1,16 @@
 """Test the simplified MCP server functionality."""
 
 import asyncio
+import signal
 from unittest.mock import AsyncMock
 
 import pytest
+import uvicorn
 
 from jupyter_server_mcp.mcp_server import (
     MCPServer,
     MCPServerPortError,
+    _EmbeddedUvicornServer,
     _wrap_with_json_conversion,
 )
 
@@ -21,6 +24,10 @@ async def async_function(name: str) -> str:
     """Async greeting function."""
     await asyncio.sleep(0.001)  # Small delay
     return f"Hello, {name}!"
+
+
+async def empty_asgi_app(_scope, _receive, _send) -> None:
+    """Minimal ASGI app for Uvicorn server unit tests."""
 
 
 def function_with_docstring(message: str) -> str:
@@ -171,11 +178,29 @@ class TestMCPServer:
         assert info["name"] == "simple_function"
         assert info["function"] == simple_function
 
+    def test_embedded_uvicorn_server_does_not_capture_signals(self, monkeypatch):
+        """Test that embedded Uvicorn leaves Ctrl-C handling to Jupyter."""
+        captured_signals = []
+
+        def record_signal(sig, handler):
+            captured_signals.append((sig, handler))
+
+        monkeypatch.setattr(signal, "signal", record_signal)
+
+        uvicorn_server = _EmbeddedUvicornServer(
+            config=uvicorn.Config(app=empty_asgi_app)
+        )
+
+        with uvicorn_server.capture_signals():
+            pass
+
+        assert captured_signals == []
+
     @pytest.mark.asyncio
     async def test_start_server_checks_port_before_uvicorn(self, monkeypatch):
         """Test that occupied ports fail before Uvicorn starts."""
         server = MCPServer(port=3001)
-        server.mcp.run_http_async = AsyncMock()
+        server._run_http_async_without_signals = AsyncMock()
 
         def raise_port_error(host, port):
             msg = f"Port {port} is already in use on {host}"
@@ -188,14 +213,14 @@ class TestMCPServer:
         with pytest.raises(MCPServerPortError, match="Port 3001 is already in use"):
             await server.start_server()
 
-        server.mcp.run_http_async.assert_not_called()
+        server._run_http_async_without_signals.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_start_server_runs_http_after_port_check(self, monkeypatch):
         """Test that startup continues when the configured port can be bound."""
         checked_addresses = []
         server = MCPServer(port=3050)
-        server.mcp.run_http_async = AsyncMock()
+        server._run_http_async_without_signals = AsyncMock()
 
         def record_port_check(host, port):
             checked_addresses.append((host, port))
@@ -207,7 +232,21 @@ class TestMCPServer:
         await server.start_server()
 
         assert checked_addresses == [("localhost", 3050)]
-        server.mcp.run_http_async.assert_called_once_with(host="localhost", port=3050)
+        server._run_http_async_without_signals.assert_called_once_with(
+            host="localhost", port=3050
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_server_requests_uvicorn_exit(self):
+        """Test that graceful shutdown asks the embedded Uvicorn server to exit."""
+        server = MCPServer()
+        server._uvicorn_server = _EmbeddedUvicornServer(
+            config=uvicorn.Config(app=empty_asgi_app)
+        )
+
+        await server.stop_server()
+
+        assert server._uvicorn_server.should_exit is True
 
 
 class TestMCPServerDirect:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -41,10 +41,11 @@ class FakeSocket:
         self.socktype = socktype
         self.proto = proto
         self.bound_address = None
+        self.closed = False
         self.socket_options = []
 
     def close(self):
-        pass
+        self.closed = True
 
     def setsockopt(self, *args):
         self.socket_options.append(args)
@@ -249,6 +250,7 @@ class TestMCPServer:
 
         bound_addresses = {sock.bound_address for sock in created_sockets}
         assert bound_addresses == {("::1", 3001, 0, 0), ("127.0.0.1", 3001)}
+        assert all(sock.closed for sock in created_sockets)
 
     def test_port_check_does_not_force_reuseaddr_on_windows(self, monkeypatch):
         """Test that the preflight check mirrors asyncio's Windows bind policy."""
@@ -276,9 +278,11 @@ class TestMCPServer:
         _ensure_port_available("localhost", 3001)
 
         assert created_sockets[0].socket_options == []
+        assert created_sockets[0].closed is True
 
     def test_port_check_raises_when_resolved_address_is_in_use(self, monkeypatch):
         """Test that any in-use resolved address fails the preflight check."""
+        created_sockets = []
 
         class FailingSocket(FakeSocket):
             def bind(self, sockaddr):
@@ -293,7 +297,9 @@ class TestMCPServer:
             return [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0))]
 
         def fake_socket(family, socktype, proto):
-            return FailingSocket(family, socktype, proto)
+            sock = FailingSocket(family, socktype, proto)
+            created_sockets.append(sock)
+            return sock
 
         monkeypatch.setattr(
             "jupyter_server_mcp.mcp_server.socket.getaddrinfo", fake_getaddrinfo
@@ -302,6 +308,8 @@ class TestMCPServer:
 
         with pytest.raises(MCPServerPortError, match="Cannot start MCP server"):
             _ensure_port_available("localhost", 3001)
+
+        assert all(sock.closed for sock in created_sockets)
 
     def test_port_check_ignores_unavailable_resolved_addresses(self, monkeypatch):
         """Test that unusable address families do not fail if another bind works."""
@@ -339,6 +347,7 @@ class TestMCPServer:
         _ensure_port_available("localhost", 3001)
 
         assert ("127.0.0.1", 3001) in {sock.bound_address for sock in created_sockets}
+        assert all(sock.closed for sock in created_sockets)
 
     @pytest.mark.asyncio
     async def test_start_server_checks_port_before_uvicorn(self, monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,7 +1,9 @@
 """Test the simplified MCP server functionality."""
 
 import asyncio
+import errno
 import signal
+import socket
 from unittest.mock import AsyncMock
 
 import pytest
@@ -11,6 +13,7 @@ from jupyter_server_mcp.mcp_server import (
     MCPServer,
     MCPServerPortError,
     _EmbeddedUvicornServer,
+    _ensure_port_available,
     _wrap_with_json_conversion,
 )
 
@@ -28,6 +31,26 @@ async def async_function(name: str) -> str:
 
 async def empty_asgi_app(_scope, _receive, _send) -> None:
     """Minimal ASGI app for Uvicorn server unit tests."""
+
+
+class FakeSocket:
+    """Minimal socket test double."""
+
+    def __init__(self, family, socktype, proto):
+        self.family = family
+        self.socktype = socktype
+        self.proto = proto
+        self.bound_address = None
+        self.socket_options = []
+
+    def close(self):
+        pass
+
+    def setsockopt(self, *args):
+        self.socket_options.append(args)
+
+    def bind(self, sockaddr):
+        self.bound_address = sockaddr
 
 
 def function_with_docstring(message: str) -> str:
@@ -195,6 +218,127 @@ class TestMCPServer:
             pass
 
         assert captured_signals == []
+
+    def test_port_check_uses_all_resolved_addresses(self, monkeypatch):
+        """Test that localhost-style hosts are checked for IPv6 and IPv4 binds."""
+        addr_infos = [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 3001, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 3001)),
+        ]
+        created_sockets = []
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            assert (host, port) == ("localhost", 3001)
+            assert kwargs == {
+                "type": socket.SOCK_STREAM,
+                "flags": socket.AI_PASSIVE,
+            }
+            return addr_infos
+
+        def fake_socket(family, socktype, proto):
+            sock = FakeSocket(family, socktype, proto)
+            created_sockets.append(sock)
+            return sock
+
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server.socket.getaddrinfo", fake_getaddrinfo
+        )
+        monkeypatch.setattr("jupyter_server_mcp.mcp_server.socket.socket", fake_socket)
+
+        _ensure_port_available("localhost", 3001)
+
+        bound_addresses = {sock.bound_address for sock in created_sockets}
+        assert bound_addresses == {("::1", 3001, 0, 0), ("127.0.0.1", 3001)}
+
+    def test_port_check_does_not_force_reuseaddr_on_windows(self, monkeypatch):
+        """Test that the preflight check mirrors asyncio's Windows bind policy."""
+        created_sockets = []
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            assert kwargs == {
+                "type": socket.SOCK_STREAM,
+                "flags": socket.AI_PASSIVE,
+            }
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (host, port))]
+
+        def fake_socket(family, socktype, proto):
+            sock = FakeSocket(family, socktype, proto)
+            created_sockets.append(sock)
+            return sock
+
+        monkeypatch.setattr("jupyter_server_mcp.mcp_server.os.name", "nt")
+        monkeypatch.setattr("jupyter_server_mcp.mcp_server.sys.platform", "win32")
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server.socket.getaddrinfo", fake_getaddrinfo
+        )
+        monkeypatch.setattr("jupyter_server_mcp.mcp_server.socket.socket", fake_socket)
+
+        _ensure_port_available("localhost", 3001)
+
+        assert created_sockets[0].socket_options == []
+
+    def test_port_check_raises_when_resolved_address_is_in_use(self, monkeypatch):
+        """Test that any in-use resolved address fails the preflight check."""
+
+        class FailingSocket(FakeSocket):
+            def bind(self, sockaddr):
+                raise OSError(errno.EADDRINUSE, f"Address already in use: {sockaddr}")
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            assert host == "localhost"
+            assert kwargs == {
+                "type": socket.SOCK_STREAM,
+                "flags": socket.AI_PASSIVE,
+            }
+            return [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0))]
+
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server.socket.getaddrinfo", fake_getaddrinfo
+        )
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server.socket.socket",
+            lambda family, socktype, proto: FailingSocket(family, socktype, proto),
+        )
+
+        with pytest.raises(MCPServerPortError, match="Cannot start MCP server"):
+            _ensure_port_available("localhost", 3001)
+
+    def test_port_check_ignores_unavailable_resolved_addresses(self, monkeypatch):
+        """Test that unusable address families do not fail if another bind works."""
+        created_sockets = []
+
+        class PartiallyFailingSocket(FakeSocket):
+            def bind(self, sockaddr):
+                if self.family == socket.AF_INET6:
+                    raise OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+                super().bind(sockaddr)
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            assert host == "localhost"
+            assert kwargs == {
+                "type": socket.SOCK_STREAM,
+                "flags": socket.AI_PASSIVE,
+            }
+            return [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port)),
+            ]
+
+        def fake_socket(family, socktype, proto):
+            sock = PartiallyFailingSocket(family, socktype, proto)
+            created_sockets.append(sock)
+            return sock
+
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server.socket.getaddrinfo", fake_getaddrinfo
+        )
+        monkeypatch.setattr("jupyter_server_mcp.mcp_server.socket.socket", fake_socket)
+
+        _ensure_port_available("localhost", 3001)
+
+        assert ("127.0.0.1", 3001) in {
+            sock.bound_address for sock in created_sockets
+        }
 
     @pytest.mark.asyncio
     async def test_start_server_checks_port_before_uvicorn(self, monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,10 +1,15 @@
 """Test the simplified MCP server functionality."""
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
-from jupyter_server_mcp.mcp_server import MCPServer, _wrap_with_json_conversion
+from jupyter_server_mcp.mcp_server import (
+    MCPServer,
+    MCPServerPortError,
+    _wrap_with_json_conversion,
+)
 
 
 def simple_function(x: int, y: int) -> int:
@@ -165,6 +170,44 @@ class TestMCPServer:
         assert info is not None
         assert info["name"] == "simple_function"
         assert info["function"] == simple_function
+
+    @pytest.mark.asyncio
+    async def test_start_server_checks_port_before_uvicorn(self, monkeypatch):
+        """Test that occupied ports fail before Uvicorn starts."""
+        server = MCPServer(port=3001)
+        server.mcp.run_http_async = AsyncMock()
+
+        def raise_port_error(host, port):
+            msg = f"Port {port} is already in use on {host}"
+            raise MCPServerPortError(msg)
+
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server._ensure_port_available", raise_port_error
+        )
+
+        with pytest.raises(MCPServerPortError, match="Port 3001 is already in use"):
+            await server.start_server()
+
+        server.mcp.run_http_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_server_runs_http_after_port_check(self, monkeypatch):
+        """Test that startup continues when the configured port can be bound."""
+        checked_addresses = []
+        server = MCPServer(port=3050)
+        server.mcp.run_http_async = AsyncMock()
+
+        def record_port_check(host, port):
+            checked_addresses.append((host, port))
+
+        monkeypatch.setattr(
+            "jupyter_server_mcp.mcp_server._ensure_port_available", record_port_check
+        )
+
+        await server.start_server()
+
+        assert checked_addresses == [("localhost", 3050)]
+        server.mcp.run_http_async.assert_called_once_with(host="localhost", port=3050)
 
 
 class TestMCPServerDirect:


### PR DESCRIPTION
Fixes https://github.com/jupyter-ai-contrib/jupyter-server-mcp/issues/13

- [x] Better handle ports already in use as discussed in https://github.com/jupyterlab/jupyter-ai/issues/1557
- [x] Require `fastmcp>=3`
- [x] Improve handling of keyboard interrupts to avoid shutting down the MCP server while the jupyter server is still running:

Before Ctrl-C a running Jupyter Server would shut down the MCP server even if the user did not confirm the shutdown:

<img width="1260" height="252" alt="image" src="https://github.com/user-attachments/assets/92e52f2c-ee56-4e1e-ab1e-1f8941deb56c" />


After the change:

<img width="1056" height="312" alt="image" src="https://github.com/user-attachments/assets/d12a4945-58fc-46ca-a9de-89fdadb5a88a" />
