### PR TITLE
Disallow authlib==1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 
 dependencies = [
     "jupyter_server>=1.6,<3",
-    "fastmcp>=2.0.0"
+    "fastmcp>=2.0.0",
+    "authlib!=1.7.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #18.

The `authlib==1.7.0` release introduced an implicitly required dependency on `joserfc`. This causes an error when `jupyter_server_mcp` is imported:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from confluent_kafka.schema_registry import SchemaRegistryClient
  File ".../confluent_kafka/schema_registry/schema_registry_client.py", line 19, in <module>
    from ._async.schema_registry_client import *
  File ".../confluent_kafka/schema_registry/_async/schema_registry_client.py", line 32, in <module>
    from authlib.integrations.httpx_client import AsyncOAuth2Client
  File ".../authlib/integrations/httpx_client/__init__.py", line 8, in <module>
    from ..base_client import OAuthError
  File ".../authlib/integrations/base_client/__init__.py", line 13, in <module>
    from .sync_openid import OpenIDMixin
  File ".../authlib/integrations/base_client/sync_openid.py", line 1, in <module>
    from joserfc import jwt
ModuleNotFoundError: No module named 'joserfc'
```

This is breaking the MCP tool use for new installations of `jupyter_server_mcp`. This PR fixes that by explicitly disallowing `authlib==1.7.0`. This does not add a new dependency since `authlib` is required in latest `fastmcp`.