### PR TITLE
Add stdio proxy launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This extension provides a simplified, trait-based approach to exposing Jupyter f
 - **Automatic Tool Discovery**: Python packages can expose tools via entrypoints
 - **Jupyter Integration**: Seamless integration with Jupyter Server extension system
 - **Streamable HTTP Transport**: FastMCP-based HTTP server with proper MCP protocol support
-- **Stdio Proxy**: Stable `jupyter-server-mcp-proxy` / `python -m jupyter_server_mcp.proxy` entry point that auto-discovers the running Jupyter MCP server — no hard-coded port needed in client configuration, and launchable via `uvx` from outside the Jupyter environment
-- **Ephemeral Port by Default**: The MCP server binds a free port chosen by the OS unless you pin `mcp_port`, so multiple Jupyter servers can run in parallel without conflicts
+- **Stdio Proxy**: Stable `jupyter-server-mcp-proxy` / `python -m jupyter_server_mcp.proxy` entry point that auto-discovers the running Jupyter MCP server — client configuration stays the same even if the port changes, and it is launchable via `uvx` from outside the Jupyter environment
+- **Multi-Instance Ready**: Set `mcp_port = 0` to ask the OS for a free ephemeral port, so multiple Jupyter servers can run in parallel; the stdio proxy auto-discovers whichever port was chosen
 - **Traitlets Configuration**: Full configuration support through Jupyter's traitlets system
 
 ## Installation
@@ -62,11 +62,12 @@ c = get_config()
 # Basic MCP server settings
 c.MCPExtensionApp.mcp_name = "My Jupyter MCP Server"
 
-# Optional: pin the MCP server to a specific port.
-# By default (mcp_port = 0), the OS picks a free ephemeral port, which lets
-# multiple Jupyter servers coexist. Only set a fixed port when an MCP client
-# connects directly over HTTP and needs a stable URL.
-# c.MCPExtensionApp.mcp_port = 3001
+# The MCP server listens on port 3001 by default. Override it with:
+# c.MCPExtensionApp.mcp_port = 8080
+# Set to 0 to let the OS pick a free port — useful when running multiple
+# Jupyter servers side by side. The stdio proxy (below) auto-discovers the
+# chosen port, so clients do not need to be reconfigured.
+# c.MCPExtensionApp.mcp_port = 0
 
 # Register tools from existing packages
 c.MCPExtensionApp.mcp_tools = [
@@ -91,28 +92,25 @@ c.MCPExtensionApp.mcp_tools = [
 jupyter lab --config=jupyter_config.py
 ```
 
-By default, the MCP server binds an **ephemeral port** (the OS picks a free one),
-so multiple Jupyter servers can run side-by-side without port conflicts. The stdio
-proxy (see below) auto-discovers whichever port was chosen, so client configuration
-does not need to change when the port does.
+By default, the MCP server listens on **port 3001**. If that port is already in
+use — for example when a second Jupyter server is already running — startup
+fails with a clear error instead of silently choosing another port. To run
+multiple Jupyter servers side-by-side, set `c.MCPExtensionApp.mcp_port = 0` so
+the OS assigns a free port. The stdio proxy (see below) auto-discovers
+whichever port was chosen, so client configuration does not need to change.
 
-If you want a fixed, predictable URL — for example when connecting an MCP client
-directly over HTTP — set `c.MCPExtensionApp.mcp_port = 3001` (or any other port)
-in your config. Any trait can also be set directly on the command line:
+Any trait can also be set on the command line:
 
 ```bash
-jupyter lab --MCPExtensionApp.mcp_port=3001
+jupyter lab --MCPExtensionApp.mcp_port=8080
 ```
-
-When a fixed port is configured and already in use, startup fails with a clear
-error instead of silently choosing another port.
 
 ### 3. CLI MCP Client Configuration
 
 There are two supported ways to wire an MCP client to this extension:
 
-1. **Stdio proxy (recommended)** — the client launches a small stdio proxy (`jupyter-server-mcp-proxy` or `python -m jupyter_server_mcp.proxy`), which auto-discovers the running Jupyter MCP server and bridges stdio to its HTTP endpoint. Because the server defaults to an ephemeral port, this is the only configuration that works unchanged when multiple Jupyter servers run side-by-side or when the port shifts between runs.
-2. **Direct HTTP** — point the client at `http://localhost:<port>/mcp`. This requires pinning `c.MCPExtensionApp.mcp_port` to a known value, and works well when you run a single Jupyter server on a stable port.
+1. **Stdio proxy (recommended)** — the client launches a small stdio proxy (`jupyter-server-mcp-proxy` or `python -m jupyter_server_mcp.proxy`), which auto-discovers the running Jupyter MCP server and bridges stdio to its HTTP endpoint. This keeps working unchanged when multiple Jupyter servers run side-by-side or when `mcp_port = 0` picks a different port each run.
+2. **Direct HTTP** — point the client at `http://localhost:3001/mcp` (or whichever port you configured). Works well when you run a single Jupyter server on a stable port.
 
 When multiple Jupyter servers are running on the same machine, the stdio proxy picks the one whose Jupyter root directory is the most specific ancestor of the MCP client's current working directory. If no server's root directory contains that working directory, or if several tie, the proxy refuses to guess and asks you to disambiguate with `--url` or by setting `JUPYTER_SERVER_MCP_URL`.
 
@@ -230,18 +228,15 @@ The proxy accepts a few optional arguments (append them to `args`):
 
 #### Option B — Direct HTTP
 
-Direct HTTP requires a fixed, known port. Configure one explicitly (the
-default `mcp_port = 0` picks an ephemeral port each run, which is good for
-the stdio proxy but not usable as a stable URL):
+The extension exposes a FastMCP streamable HTTP endpoint at
+`http://localhost:3001/mcp` by default. Override the port with
+`c.MCPExtensionApp.mcp_port` if you need a different one; replace `3001`
+below with whatever you chose. If a client asks for a transport type,
+pick `HTTP` or `Streamable HTTP`.
 
-```python
-c.MCPExtensionApp.mcp_port = 3001
-```
-
-The extension then exposes a FastMCP streamable HTTP endpoint at
-`http://localhost:3001/mcp`. Replace `3001` below with whichever port you
-chose. If a client asks for a transport type, pick `HTTP` or
-`Streamable HTTP`.
+> **Note:** Direct HTTP requires a fixed, known port. If you set
+> `c.MCPExtensionApp.mcp_port = 0` for multi-instance support, use the
+> stdio proxy instead — the ephemeral port is not suitable as a stable URL.
 
 **OpenCode**
 
@@ -373,7 +368,7 @@ Jupyter Server extension that manages the MCP server lifecycle:
 
 **Configuration Traits:**
 - `mcp_name` - Server name (default: "Jupyter MCP Server")
-- `mcp_port` - Server port (default: 0, meaning the OS picks a free ephemeral port)
+- `mcp_port` - Server port (default: 3001). Set to 0 to let the OS pick a free port — useful when running multiple servers side by side.
 - `mcp_tools` - List of tools to register (format: "module:function")
 - `use_tool_discovery` - Enable automatic tool discovery via entrypoints (default: True)
 
@@ -432,9 +427,9 @@ c.MCPExtensionApp.use_tool_discovery = False
 ```python
 c = get_config()
 
-# Optional: pin the MCP server to a specific port (default: 0 — ephemeral).
-# Only needed when an MCP client connects directly over HTTP.
-# c.MCPExtensionApp.mcp_port = 3001
+# The MCP server defaults to port 3001. Override it with:
+# c.MCPExtensionApp.mcp_port = 8080
+# Or set to 0 to let the OS pick a free port (requires the stdio proxy).
 ```
 
 ### Full Configuration

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This extension provides a simplified, trait-based approach to exposing Jupyter f
 - **Automatic Tool Discovery**: Python packages can expose tools via entrypoints
 - **Jupyter Integration**: Seamless integration with Jupyter Server extension system
 - **Streamable HTTP Transport**: FastMCP-based HTTP server with proper MCP protocol support
+- **Stdio Proxy**: Stable `jupyter-server-mcp-proxy` / `python -m jupyter_server_mcp.proxy` entry point that auto-discovers the running Jupyter MCP server — no hard-coded port needed in client configuration, and launchable via `uvx` from outside the Jupyter environment
+- **Ephemeral Port by Default**: The MCP server binds a free port chosen by the OS unless you pin `mcp_port`, so multiple Jupyter servers can run in parallel without conflicts
 - **Traitlets Configuration**: Full configuration support through Jupyter's traitlets system
 
 ## Installation
@@ -60,10 +62,11 @@ c = get_config()
 # Basic MCP server settings
 c.MCPExtensionApp.mcp_name = "My Jupyter MCP Server"
 
-# Optional: override the default MCP port (3001).
-# If 3001 is already in use, choose another fixed port and use the same
-# port in your MCP client configuration below.
-# c.MCPExtensionApp.mcp_port = 8080
+# Optional: pin the MCP server to a specific port.
+# By default (mcp_port = 0), the OS picks a free ephemeral port, which lets
+# multiple Jupyter servers coexist. Only set a fixed port when an MCP client
+# connects directly over HTTP and needs a stable URL.
+# c.MCPExtensionApp.mcp_port = 3001
 
 # Register tools from existing packages
 c.MCPExtensionApp.mcp_tools = [
@@ -88,25 +91,157 @@ c.MCPExtensionApp.mcp_tools = [
 jupyter lab --config=jupyter_config.py
 ```
 
-The MCP server will start automatically on `http://localhost:3001/mcp` by default.
-If the configured port is already in use, startup fails with a clear error instead
-of silently choosing another port, because MCP clients need to be configured with
-the actual endpoint URL.
+By default, the MCP server binds an **ephemeral port** (the OS picks a free one),
+so multiple Jupyter servers can run side-by-side without port conflicts. The stdio
+proxy (see below) auto-discovers whichever port was chosen, so client configuration
+does not need to change when the port does.
 
-Any trait can also be set directly on the command line, without a config file. For example, to override the port:
+If you want a fixed, predictable URL — for example when connecting an MCP client
+directly over HTTP — set `c.MCPExtensionApp.mcp_port = 3001` (or any other port)
+in your config. Any trait can also be set directly on the command line:
 
 ```bash
-jupyter lab --MCPExtensionApp.mcp_port=8080
+jupyter lab --MCPExtensionApp.mcp_port=3001
 ```
+
+When a fixed port is configured and already in use, startup fails with a clear
+error instead of silently choosing another port.
 
 ### 3. CLI MCP Client Configuration
 
-By default, this extension exposes a FastMCP streamable HTTP endpoint at `http://localhost:3001/mcp`.
-If you override the port via `c.MCPExtensionApp.mcp_port` or the `--MCPExtensionApp.mcp_port=<port>` CLI flag, replace `3001` in the examples below.
-If a client asks for a transport type, choose `HTTP` or `Streamable HTTP`.
+There are two supported ways to wire an MCP client to this extension:
+
+1. **Stdio proxy (recommended)** — the client launches a small stdio proxy (`jupyter-server-mcp-proxy` or `python -m jupyter_server_mcp.proxy`), which auto-discovers the running Jupyter MCP server and bridges stdio to its HTTP endpoint. Because the server defaults to an ephemeral port, this is the only configuration that works unchanged when multiple Jupyter servers run side-by-side or when the port shifts between runs.
+2. **Direct HTTP** — point the client at `http://localhost:<port>/mcp`. This requires pinning `c.MCPExtensionApp.mcp_port` to a known value, and works well when you run a single Jupyter server on a stable port.
+
+When multiple Jupyter servers are running on the same machine, the stdio proxy picks the one whose Jupyter root directory is the most specific ancestor of the MCP client's current working directory. If no server's root directory contains that working directory, or if several tie, the proxy refuses to guess and asks you to disambiguate with `--url` or by setting `JUPYTER_SERVER_MCP_URL`.
 
 The list below is intentionally curated rather than exhaustive and focuses on terminal-based coding agents.
 For a broader, community-maintained directory of MCP-compatible clients, see the MCP client directory: <https://modelcontextprotocol.io/clients>.
+
+#### Option A — Stdio proxy (recommended)
+
+The proxy can be launched in two ways:
+
+- **`uvx`** — ideal for MCP clients that are not installed inside the same
+  Python environment as Jupyter. [uv](https://docs.astral.sh/uv/) installs
+  `jupyter-server-mcp` into a cached, ephemeral environment and runs its
+  `jupyter-server-mcp-proxy` console script. The runtime info file the
+  extension writes is stored in the per-user Jupyter runtime directory, so
+  auto-discovery works across environments.
+- **`python -m jupyter_server_mcp.proxy`** — use when the client is
+  already running in an environment that has `jupyter-server-mcp`
+  installed.
+
+The examples below show the `uvx` form. Swap in the `python -m` form by
+replacing `"command": "uvx", "args": ["--from", "jupyter-server-mcp", "jupyter-server-mcp-proxy"]`
+with `"command": "python", "args": ["-m", "jupyter_server_mcp.proxy"]`.
+
+**Claude Code**
+
+Add the following to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "jupyter-mcp": {
+      "command": "uvx",
+      "args": ["--from", "jupyter-server-mcp", "jupyter-server-mcp-proxy"]
+    }
+  }
+}
+```
+
+Or use the `claude` CLI:
+
+```bash
+claude mcp add jupyter-mcp -- uvx --from jupyter-server-mcp jupyter-server-mcp-proxy
+```
+
+**Codex**
+
+Use the `codex` CLI:
+
+```bash
+codex mcp add jupyter-mcp -- uvx --from jupyter-server-mcp jupyter-server-mcp-proxy
+```
+
+Or add the following to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.jupyter-mcp]
+command = "uvx"
+args = ["--from", "jupyter-server-mcp", "jupyter-server-mcp-proxy"]
+```
+
+**OpenCode**
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "jupyter-mcp": {
+      "type": "local",
+      "command": ["uvx", "--from", "jupyter-server-mcp", "jupyter-server-mcp-proxy"],
+      "enabled": true
+    }
+  }
+}
+```
+
+**Gemini CLI**
+
+```json
+{
+  "mcpServers": {
+    "jupyter-mcp": {
+      "command": "uvx",
+      "args": ["--from", "jupyter-server-mcp", "jupyter-server-mcp-proxy"]
+    }
+  }
+}
+```
+
+**Copilot CLI**
+
+```json
+{
+  "mcpServers": {
+    "jupyter-mcp": {
+      "type": "local",
+      "command": "uvx",
+      "args": ["--from", "jupyter-server-mcp", "jupyter-server-mcp-proxy"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Pin to a specific version with `--from jupyter-server-mcp==X.Y.Z` when you
+need to match the server side exactly.
+
+The proxy accepts a few optional arguments (append them to `args`):
+
+- `--url URL` — bypass auto-discovery and connect to an explicit MCP endpoint
+- `--runtime-dir DIR` — look in a specific Jupyter runtime directory
+- `--cwd DIR` — use a different directory when disambiguating between servers
+
+`JUPYTER_SERVER_MCP_URL` is equivalent to `--url` and takes precedence over discovery when set.
+
+#### Option B — Direct HTTP
+
+Direct HTTP requires a fixed, known port. Configure one explicitly (the
+default `mcp_port = 0` picks an ephemeral port each run, which is good for
+the stdio proxy but not usable as a stable URL):
+
+```python
+c.MCPExtensionApp.mcp_port = 3001
+```
+
+The extension then exposes a FastMCP streamable HTTP endpoint at
+`http://localhost:3001/mcp`. Replace `3001` below with whichever port you
+chose. If a client asks for a transport type, pick `HTTP` or
+`Streamable HTTP`.
 
 **OpenCode**
 
@@ -238,7 +373,7 @@ Jupyter Server extension that manages the MCP server lifecycle:
 
 **Configuration Traits:**
 - `mcp_name` - Server name (default: "Jupyter MCP Server")
-- `mcp_port` - Server port (default: 3001)
+- `mcp_port` - Server port (default: 0, meaning the OS picks a free ephemeral port)
 - `mcp_tools` - List of tools to register (format: "module:function")
 - `use_tool_discovery` - Enable automatic tool discovery via entrypoints (default: True)
 
@@ -297,9 +432,9 @@ c.MCPExtensionApp.use_tool_discovery = False
 ```python
 c = get_config()
 
-# Optional: override the default port (3001)
-# Use a fixed port that matches your MCP client configuration.
-# c.MCPExtensionApp.mcp_port = 8080
+# Optional: pin the MCP server to a specific port (default: 0 — ephemeral).
+# Only needed when an MCP client connects directly over HTTP.
+# c.MCPExtensionApp.mcp_port = 3001
 ```
 
 ### Full Configuration
@@ -364,10 +499,14 @@ jupyter_server_mcp/
 ├── jupyter_server_mcp/
 │   ├── __init__.py
 │   ├── mcp_server.py      # Core MCP server implementation
-│   └── extension.py       # Jupyter Server extension
+│   ├── extension.py       # Jupyter Server extension
+│   ├── proxy.py           # Stdio MCP proxy entrypoint (python -m jupyter_server_mcp.proxy)
+│   └── runtime.py         # Runtime info-file helpers shared between the extension and the proxy
 ├── tests/
 │   ├── test_mcp_server.py # MCPServer tests
-│   └── test_extension.py  # Extension tests  
+│   ├── test_extension.py  # Extension tests
+│   ├── test_proxy.py      # Stdio proxy tests
+│   └── test_runtime.py    # Runtime info-file helper tests
 ├── demo/
 │   ├── jupyter_config.py  # Example configuration
 │   └── *.py              # Debug/diagnostic scripts

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -45,14 +45,14 @@ class MCPExtensionApp(ExtensionApp):
 
     # Configurable traits
     mcp_port = Int(
-        default_value=0,
+        default_value=3001,
         help=(
             "Port for the MCP server to listen on. "
-            "Defaults to 0, which asks the OS to pick a free port — "
-            "multiple Jupyter servers can then run side by side and the "
-            "stdio proxy (python -m jupyter_server_mcp.proxy) auto-discovers "
-            "each one. Set a fixed port (e.g. 3001) when clients connect "
-            "directly over HTTP."
+            "Defaults to 3001. Set to 0 to ask the OS to pick a free port — "
+            "useful when running multiple Jupyter servers side by side. "
+            "When port 0 is used, the stdio proxy "
+            "(python -m jupyter_server_mcp.proxy) can auto-discover the "
+            "chosen port via the runtime info file."
         ),
     ).tag(config=True)
 

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -6,13 +6,35 @@ import importlib
 import importlib.metadata
 import inspect
 import logging
+import os
+from pathlib import Path
 
+from jupyter_core.paths import jupyter_runtime_dir
 from jupyter_server.extension.application import ExtensionApp
 from traitlets import Bool, Int, List, Unicode
 
 from .mcp_server import MCPServer
+from .runtime import info_file_path, remove_info_file, write_info_file
 
 logger = logging.getLogger(__name__)
+
+# Wildcard bind addresses are valid for listening but cannot be dialed.
+_WILDCARD_CONNECT_HOSTS = {
+    "0.0.0.0": "127.0.0.1",
+    "": "127.0.0.1",
+    "::": "::1",
+    "::0": "::1",
+}
+
+
+def _connect_host(bind_host: str) -> str:
+    """Return a host usable in a client URL for ``bind_host``.
+
+    Bind addresses like ``0.0.0.0`` or ``::`` instruct a server to listen on
+    all interfaces, but clients cannot connect to those literal values. Map
+    them to the matching loopback address so the published URL is dialable.
+    """
+    return _WILDCARD_CONNECT_HOSTS.get(bind_host, bind_host)
 
 
 class MCPExtensionApp(ExtensionApp):
@@ -22,9 +44,17 @@ class MCPExtensionApp(ExtensionApp):
     description = "Jupyter Server extension providing MCP server for tool registration"
 
     # Configurable traits
-    mcp_port = Int(default_value=3001, help="Port for the MCP server to listen on").tag(
-        config=True
-    )
+    mcp_port = Int(
+        default_value=0,
+        help=(
+            "Port for the MCP server to listen on. "
+            "Defaults to 0, which asks the OS to pick a free port — "
+            "multiple Jupyter servers can then run side by side and the "
+            "stdio proxy (python -m jupyter_server_mcp.proxy) auto-discovers "
+            "each one. Set a fixed port (e.g. 3001) when clients connect "
+            "directly over HTTP."
+        ),
+    ).tag(config=True)
 
     mcp_name = Unicode(
         default_value="Jupyter MCP Server", help="Name for the MCP server"
@@ -51,6 +81,8 @@ class MCPExtensionApp(ExtensionApp):
     mcp_server_instance: object | None = None
     mcp_server_task: asyncio.Task | None = None
     mcp_shutdown_timeout = 5
+    mcp_startup_timeout = 10
+    _runtime_info_path: Path | None = None
 
     def _load_function_from_string(self, tool_spec: str):
         """Load a function from a string specification.
@@ -192,20 +224,34 @@ class MCPExtensionApp(ExtensionApp):
         # Configuration is handled by traitlets
 
     async def _confirm_mcp_server_started(self):
-        """Raise if the background MCP server task failed during startup."""
+        """Wait for the MCP server to bind its port, or raise if startup fails."""
         task = self.mcp_server_task
-        if task is None:
+        instance = self.mcp_server_instance
+        if task is None or instance is None:
             return
 
-        done, _ = await asyncio.wait(
-            {task}, timeout=0.5, return_when=asyncio.FIRST_COMPLETED
-        )
-        if not done:
-            return
+        bound_wait = asyncio.ensure_future(instance.wait_until_bound())
+        try:
+            done, _ = await asyncio.wait(
+                {task, bound_wait},
+                timeout=self.mcp_startup_timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            if not bound_wait.done():
+                bound_wait.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await bound_wait
 
-        await task
-        msg = "MCP server exited during startup"
-        raise RuntimeError(msg)
+        if task in done:
+            # The server task finished before binding — surface its exception.
+            await task
+            msg = "MCP server exited during startup"
+            raise RuntimeError(msg)
+
+        if bound_wait not in done:
+            msg = f"MCP server did not bind within {self.mcp_startup_timeout} seconds"
+            raise TimeoutError(msg)
 
     async def _stop_mcp_server_task(self):
         """Stop the MCP server through its own shutdown path, then fall back."""
@@ -234,9 +280,10 @@ class MCPExtensionApp(ExtensionApp):
     async def start_extension(self):
         """Start the extension - called after Jupyter Server starts."""
         try:
-            self.log.info(
-                f"Starting MCP server '{self.mcp_name}' on port {self.mcp_port}"
+            port_desc = (
+                "an ephemeral port" if self.mcp_port == 0 else f"port {self.mcp_port}"
             )
+            self.log.info(f"Starting MCP server '{self.mcp_name}' on {port_desc}")
 
             self.mcp_server_instance = MCPServer(
                 parent=self, name=self.mcp_name, port=self.mcp_port
@@ -254,9 +301,12 @@ class MCPExtensionApp(ExtensionApp):
 
             await self._confirm_mcp_server_started()
 
+            bound_port = getattr(self.mcp_server_instance, "port", self.mcp_port)
             registered_count = len(self.mcp_server_instance._registered_tools)
-            self.log.info(f"✅ MCP server started on port {self.mcp_port}")
+            self.log.info(f"✅ MCP server started on port {bound_port}")
             self.log.info(f"Total registered tools: {registered_count}")
+
+            self._publish_runtime_info()
 
         except Exception as e:
             if self.mcp_server_task and not self.mcp_server_task.done():
@@ -264,10 +314,59 @@ class MCPExtensionApp(ExtensionApp):
                 with contextlib.suppress(asyncio.CancelledError):
                     await self.mcp_server_task
 
+            self._clear_runtime_info()
             self.mcp_server_task = None
             self.mcp_server_instance = None
             self.log.error(f"Failed to start MCP server: {e}")
             raise
+
+    def _publish_runtime_info(self):
+        """Write a runtime info file so the stdio proxy can discover this server."""
+        try:
+            server = self.mcp_server_instance
+            bind_host = getattr(server, "host", "localhost") or "localhost"
+            port = getattr(server, "port", self.mcp_port)
+            pid = os.getpid()
+            path = info_file_path(jupyter_runtime_dir(), pid)
+            # The bind host can be a wildcard like "0.0.0.0" or "::" — those
+            # are valid bind addresses but not usable as connect targets.
+            url_host = _connect_host(bind_host)
+            info = {
+                "pid": pid,
+                "host": bind_host,
+                "port": port,
+                "url": f"http://{url_host}:{port}/mcp",
+                "name": self.mcp_name,
+                "root_dir": self._detect_root_dir(),
+            }
+            write_info_file(path, info)
+        except Exception as exc:
+            self.log.warning(f"Could not publish MCP runtime info: {exc}")
+            self._runtime_info_path = None
+            return
+
+        self._runtime_info_path = path
+        self.log.info(f"Wrote MCP runtime info file: {path}")
+
+    def _clear_runtime_info(self):
+        """Remove the runtime info file if one was written."""
+        path = self._runtime_info_path
+        if path is None:
+            return
+        try:
+            remove_info_file(path)
+        except OSError as exc:
+            self.log.warning(f"Could not remove MCP runtime info file {path}: {exc}")
+        finally:
+            self._runtime_info_path = None
+
+    def _detect_root_dir(self) -> str:
+        """Return the Jupyter server's root directory, falling back to CWD."""
+        serverapp = getattr(self, "serverapp", None)
+        root_dir = getattr(serverapp, "root_dir", None)
+        if root_dir:
+            return str(Path(root_dir).resolve())
+        return str(Path.cwd().resolve())
 
     async def _start_jupyter_server_extension(self, serverapp):  # noqa: ARG002
         """Start the extension - called after Jupyter Server starts."""
@@ -278,6 +377,7 @@ class MCPExtensionApp(ExtensionApp):
         try:
             await self._stop_mcp_server_task()
         finally:
+            self._clear_runtime_info()
             self.mcp_server_task = None
             self.mcp_server_instance = None
         self.log.info("MCP server stopped")

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -37,6 +37,13 @@ def _connect_host(bind_host: str) -> str:
     return _WILDCARD_CONNECT_HOSTS.get(bind_host, bind_host)
 
 
+def _url_host(host: str) -> str:
+    """Return ``host`` formatted for use in a URL authority."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 class MCPExtensionApp(ExtensionApp):
     """The Jupyter Server MCP extension app."""
 
@@ -330,7 +337,7 @@ class MCPExtensionApp(ExtensionApp):
             path = info_file_path(jupyter_runtime_dir(), pid)
             # The bind host can be a wildcard like "0.0.0.0" or "::" — those
             # are valid bind addresses but not usable as connect targets.
-            url_host = _connect_host(bind_host)
+            url_host = _url_host(_connect_host(bind_host))
             info = {
                 "pid": pid,
                 "host": bind_host,

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -254,11 +254,11 @@ class MCPServer(LoggingConfigurable):
     ).tag(config=True)
 
     port = Int(
-        default_value=0,
+        default_value=3001,
         help=(
             "Port for the MCP server to listen on. "
-            "Defaults to 0, which asks the OS to pick a free port. "
-            "Set a fixed port when MCP clients connect directly over HTTP."
+            "Defaults to 3001. Set to 0 to ask the OS to pick a free port — "
+            "useful when running multiple servers side by side."
         ),
     ).tag(config=True)
 

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -31,10 +31,20 @@ class MCPServerPortError(RuntimeError):
 class _EmbeddedUvicornServer(uvicorn.Server):
     """Uvicorn server variant that leaves process signals to Jupyter Server."""
 
+    def __init__(self, config: uvicorn.Config, *, on_startup_complete=None):
+        super().__init__(config)
+        self._on_startup_complete = on_startup_complete
+
     @contextlib.contextmanager
     def capture_signals(self):
         """Do not install SIGINT/SIGTERM handlers for embedded servers."""
         yield
+
+    async def startup(self, sockets=None):
+        """Run the default startup, then notify any listener that we are bound."""
+        await super().startup(sockets=sockets)
+        if self._on_startup_complete is not None:
+            self._on_startup_complete(self)
 
 
 def _ensure_port_available(host: str, port: int) -> None:
@@ -243,9 +253,14 @@ class MCPServer(LoggingConfigurable):
         default_value="Jupyter MCP Server", help="Name for the MCP server"
     ).tag(config=True)
 
-    port = Int(default_value=3001, help="Port for the MCP server to listen on").tag(
-        config=True
-    )
+    port = Int(
+        default_value=0,
+        help=(
+            "Port for the MCP server to listen on. "
+            "Defaults to 0, which asks the OS to pick a free port. "
+            "Set a fixed port when MCP clients connect directly over HTTP."
+        ),
+    ).tag(config=True)
 
     host = Unicode(
         default_value="localhost", help="Host for the MCP server to listen on"
@@ -263,6 +278,7 @@ class MCPServer(LoggingConfigurable):
         self.mcp = FastMCP(self.name)
         self._registered_tools = {}
         self._uvicorn_server: uvicorn.Server | None = None
+        self._bound_event: asyncio.Event = asyncio.Event()
         self.log.info(
             f"Initialized MCP server '{self.name}' on {self.host}:{self.port}"
         )
@@ -331,6 +347,36 @@ class MCPServer(LoggingConfigurable):
         """Get information about a specific tool."""
         return self._registered_tools.get(tool_name)
 
+    def _capture_bound_port(self, server: uvicorn.Server) -> None:
+        """Record the actual listening port once uvicorn has bound its sockets.
+
+        When uvicorn is given a hostname like ``localhost`` with port 0, it
+        binds an IPv4 and an IPv6 socket, each with its own ephemeral port.
+        Clients resolving ``localhost`` typically try IPv4 first, so prefer
+        the IPv4 port when both families are present.
+        """
+        bound_port: int | None = None
+        if server.servers:
+            for uv_server in server.servers:
+                for sock in uv_server.sockets:
+                    sockname = sock.getsockname()
+                    if not (isinstance(sockname, tuple) and len(sockname) >= 2):
+                        continue
+                    family = getattr(sock, "family", None)
+                    port = int(sockname[1])
+                    if family == socket.AF_INET:
+                        bound_port = port
+                        break
+                    if bound_port is None:
+                        bound_port = port
+                if bound_port is not None and (
+                    getattr(uv_server.sockets[0], "family", None) == socket.AF_INET
+                ):
+                    break
+        if bound_port is not None:
+            self.port = bound_port
+        self._bound_event.set()
+
     async def _run_http_async_without_signals(self, host: str, port: int) -> None:
         """Run FastMCP over HTTP without taking over process signal handlers."""
         transport = "http"
@@ -347,7 +393,9 @@ class MCPServer(LoggingConfigurable):
             ws="websockets-sansio",
             log_level=fastmcp_settings.log_level.lower(),
         )
-        server = _EmbeddedUvicornServer(config)
+        server = _EmbeddedUvicornServer(
+            config, on_startup_complete=self._capture_bound_port
+        )
         self._uvicorn_server = server
         path = getattr(app.state, "path", "").lstrip("/")
         self.log.info(
@@ -372,6 +420,13 @@ class MCPServer(LoggingConfigurable):
         if self._uvicorn_server is not None:
             self._uvicorn_server.should_exit = True
 
+    async def wait_until_bound(self, timeout: float | None = None) -> None:
+        """Block until the HTTP server has finished binding its listening port."""
+        if timeout is None:
+            await self._bound_event.wait()
+        else:
+            await asyncio.wait_for(self._bound_event.wait(), timeout=timeout)
+
     async def start_server(self, host: str | None = None):
         """Start the MCP server on the specified host and port."""
         server_host = host or self.host
@@ -379,4 +434,6 @@ class MCPServer(LoggingConfigurable):
 
         self.log.info(f"Registered tools: {list(self._registered_tools.keys())}")
 
+        # Reset (don't replace) the event so existing waiters stay subscribed.
+        self._bound_event.clear()
         await self._run_http_async_without_signals(host=server_host, port=self.port)

--- a/jupyter_server_mcp/proxy.py
+++ b/jupyter_server_mcp/proxy.py
@@ -1,0 +1,230 @@
+"""Stdio MCP proxy bridging an MCP client to a running Jupyter MCP server.
+
+The extension writes a runtime info file when it starts (see
+``jupyter_server_mcp.runtime``). This module reads those files, picks the
+server that best matches the current working directory, and forwards MCP
+traffic from stdio to the server's HTTP endpoint.
+
+Run it with ``python -m jupyter_server_mcp.proxy``. MCP clients only need
+this stable command, regardless of which port the server is actually using.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from fastmcp.server import create_proxy
+
+from .runtime import list_running_mcp_servers
+
+ENV_URL = "JUPYTER_SERVER_MCP_URL"
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyError(RuntimeError):
+    """Raised when the proxy cannot find or connect to a Jupyter MCP server."""
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m jupyter_server_mcp.proxy",
+        description=(
+            "Bridge stdio MCP traffic to a running Jupyter MCP server. "
+            "Auto-discovers the server by reading jpserver-mcp-*.json files "
+            "in the Jupyter runtime directory."
+        ),
+    )
+    parser.add_argument(
+        "--url",
+        default=None,
+        help=(
+            "Explicit MCP endpoint URL (e.g. http://localhost:3001/mcp). "
+            "Overrides auto-discovery. Also settable via the "
+            f"{ENV_URL} environment variable."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-dir",
+        default=None,
+        help=(
+            "Override the Jupyter runtime directory searched for info files. "
+            "Defaults to jupyter_core.paths.jupyter_runtime_dir()."
+        ),
+    )
+    parser.add_argument(
+        "--cwd",
+        default=None,
+        help=(
+            "Directory used when disambiguating between multiple running "
+            "servers. Defaults to the current working directory."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _is_ancestor(ancestor: Path, descendant: Path) -> bool:
+    """Return True if ``ancestor`` equals or contains ``descendant``."""
+    try:
+        descendant.relative_to(ancestor)
+    except ValueError:
+        return False
+    return True
+
+
+def _match_score(root_dir: Any, cwd: Path) -> int | None:
+    """Return a specificity score if ``cwd`` lives under ``root_dir``.
+
+    Higher scores mean a more specific (deeper) match. ``None`` means
+    ``root_dir`` is missing, invalid, or does not contain ``cwd``.
+    """
+    if not isinstance(root_dir, str) or not root_dir:
+        return None
+    try:
+        root_path = Path(root_dir).resolve()
+    except OSError:
+        return None
+    if not _is_ancestor(root_path, cwd):
+        return None
+    return len(root_path.parts)
+
+
+def _describe(server: dict[str, Any]) -> str:
+    """Return a short human-readable description of a discovered server."""
+    return (
+        f"url={server.get('url')!r} "
+        f"root_dir={server.get('root_dir')!r} "
+        f"pid={server.get('pid')}"
+    )
+
+
+def select_server(servers: list[dict[str, Any]], cwd: Path) -> dict[str, Any]:
+    """Pick the MCP server that best matches ``cwd``.
+
+    Selection rules:
+      * Zero servers → :class:`ProxyError`.
+      * Exactly one server → return it unconditionally, even if ``cwd`` is
+        not below its ``root_dir`` (assumes the user just wants to connect).
+      * Multiple servers → score each candidate by how deep its ``root_dir``
+        sits above ``cwd`` and pick the most specific. Ambiguous or missing
+        matches raise :class:`ProxyError` with a listing, so the user can
+        disambiguate via ``--url`` or the ``JUPYTER_SERVER_MCP_URL`` env var.
+    """
+    if not servers:
+        msg = (
+            "No running Jupyter MCP servers were discovered. Start Jupyter "
+            "Server with the jupyter-server-mcp extension, or pass --url / "
+            f"set ${ENV_URL}."
+        )
+        raise ProxyError(msg)
+
+    if len(servers) == 1:
+        return servers[0]
+
+    scored = [
+        (score, server)
+        for server in servers
+        for score in [_match_score(server.get("root_dir"), cwd)]
+        if score is not None
+    ]
+
+    if scored:
+        scored.sort(key=lambda item: item[0], reverse=True)
+        top_score = scored[0][0]
+        top_matches = [server for score, server in scored if score == top_score]
+        if len(top_matches) == 1:
+            return top_matches[0]
+        candidates = top_matches
+    else:
+        candidates = servers
+
+    listing = "\n".join(f"  - {_describe(server)}" for server in candidates)
+    reason = (
+        "Multiple Jupyter MCP servers match the current working directory"
+        if scored
+        else "Multiple Jupyter MCP servers are running and none contains the "
+        "current working directory"
+    )
+    msg = f"{reason}. Pick one explicitly with --url or ${ENV_URL}:\n{listing}"
+    raise ProxyError(msg)
+
+
+def _validate_explicit_url(url: str, source: str) -> str:
+    """Ensure an externally-supplied URL has an http(s) scheme."""
+    if "://" not in url:
+        msg = (
+            f"{source} must be an absolute http(s) URL "
+            f"(e.g. http://localhost:3001/mcp), got: {url!r}"
+        )
+        raise ProxyError(msg)
+    scheme = url.split("://", 1)[0].lower()
+    if scheme not in {"http", "https"}:
+        msg = f"{source} must use http or https, got scheme {scheme!r}: {url!r}"
+        raise ProxyError(msg)
+    return url
+
+
+def resolve_url(
+    url: str | None = None,
+    runtime_dir: str | None = None,
+    cwd: str | os.PathLike[str] | None = None,
+) -> str:
+    """Resolve the MCP URL from explicit input or runtime discovery."""
+    if url:
+        return _validate_explicit_url(url, source="--url")
+    env_url = os.environ.get(ENV_URL)
+    if env_url:
+        return _validate_explicit_url(env_url, source=f"${ENV_URL}")
+
+    cwd_path = Path(cwd if cwd is not None else Path.cwd()).resolve()
+    servers = list(list_running_mcp_servers(runtime_dir))
+    server = select_server(servers, cwd_path)
+
+    endpoint = server.get("url")
+    if not isinstance(endpoint, str) or not endpoint:
+        msg = f"Discovered MCP server info has no URL: {server!r}"
+        raise ProxyError(msg)
+
+    logger.info(
+        "Discovered MCP server: %s (root_dir=%s, pid=%s)",
+        endpoint,
+        server.get("root_dir"),
+        server.get("pid"),
+    )
+    return endpoint
+
+
+async def run_proxy(url: str) -> None:
+    """Run a FastMCP proxy to ``url`` over stdio."""
+    proxy = create_proxy(url)
+    await proxy.run_async(transport="stdio", show_banner=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m jupyter_server_mcp.proxy``."""
+    # MCP stdio traffic occupies stdout, so keep all logging on stderr.
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr, force=True)
+
+    args = _parse_args(argv)
+
+    try:
+        url = resolve_url(args.url, args.runtime_dir, args.cwd)
+    except ProxyError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
+    try:
+        asyncio.run(run_proxy(url))
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/jupyter_server_mcp/runtime.py
+++ b/jupyter_server_mcp/runtime.py
@@ -1,0 +1,80 @@
+"""Utilities for publishing and discovering MCP server runtime info.
+
+The MCP extension writes a JSON file to Jupyter's runtime directory when it
+starts, so that the stdio proxy can find running MCP servers without the user
+having to hard-code a port. The file is named ``jpserver-mcp-<pid>.json`` and
+uses the same directory as ``list_running_servers`` for consistency.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from jupyter_core.paths import jupyter_runtime_dir
+from jupyter_server.utils import check_pid
+
+INFO_FILE_PREFIX = "jpserver-mcp-"
+INFO_FILE_SUFFIX = ".json"
+
+
+def info_file_path(runtime_dir: str | os.PathLike[str], pid: int) -> Path:
+    """Return the path to the MCP info file for ``pid`` in ``runtime_dir``."""
+    return Path(runtime_dir) / f"{INFO_FILE_PREFIX}{pid}{INFO_FILE_SUFFIX}"
+
+
+def write_info_file(path: str | os.PathLike[str], info: dict[str, Any]) -> None:
+    """Write ``info`` as JSON to ``path`` atomically."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(json.dumps(info, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def remove_info_file(path: str | os.PathLike[str]) -> None:
+    """Remove the info file at ``path`` if it exists."""
+    with contextlib.suppress(FileNotFoundError):
+        Path(path).unlink()
+
+
+def list_running_mcp_servers(
+    runtime_dir: str | os.PathLike[str] | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield info dicts for every MCP server that appears to be running.
+
+    Stale info files — those whose owning process can no longer be found —
+    are unlinked as a side effect, mirroring ``list_running_servers`` in
+    ``jupyter_server``.
+    """
+    directory = Path(jupyter_runtime_dir() if runtime_dir is None else runtime_dir)
+    if not directory.is_dir():
+        return
+
+    for entry in sorted(directory.iterdir()):
+        name = entry.name
+        if not (name.startswith(INFO_FILE_PREFIX) and name.endswith(INFO_FILE_SUFFIX)):
+            continue
+
+        try:
+            raw = entry.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        try:
+            info = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        pid = info.get("pid")
+        if not isinstance(pid, int) or not check_pid(pid):
+            with contextlib.suppress(OSError):
+                entry.unlink()
+            continue
+
+        info["info_file"] = str(entry)
+        yield info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ file="LICENSE"
 [project.entry-points."jupyter_server.extension_points"]
 jupyter_server_mcp = "jupyter_server_mcp.extension:MCPExtensionApp"
 
+[project.scripts]
+jupyter-server-mcp-proxy = "jupyter_server_mcp.proxy:main"
+
 [tool.hatch.version]
 path = "jupyter_server_mcp/__init__.py"
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -53,7 +53,7 @@ class TestMCPExtensionApp:
         extension = MCPExtensionApp()
 
         assert extension.name == "jupyter_server_mcp"
-        assert extension.mcp_port == 0
+        assert extension.mcp_port == 3001
         assert extension.mcp_name == "Jupyter MCP Server"
 
     def test_extension_trait_configuration(self):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,12 +1,30 @@
 """Test Jupyter Server extension functionality."""
 
 import asyncio
+import importlib.metadata as importlib_metadata
+import json
+import os
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from jupyter_server_mcp.extension import MCPExtensionApp
+from jupyter_server_mcp import proxy, runtime
+from jupyter_server_mcp.extension import MCPExtensionApp, _connect_host
 from jupyter_server_mcp.mcp_server import MCPServer
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jupyter_runtime_dir(tmp_path_factory, monkeypatch):
+    """Ensure tests never write MCP info files to the real runtime directory.
+
+    Individual tests may still override this by monkey-patching again or by
+    installing their own ``runtime_dir`` fixture.
+    """
+    fake_dir = tmp_path_factory.mktemp("jupyter_runtime_dir")
+    monkeypatch.setattr(
+        "jupyter_server_mcp.extension.jupyter_runtime_dir",
+        lambda: str(fake_dir),
+    )
 
 
 async def _run_until_cancelled():
@@ -14,11 +32,16 @@ async def _run_until_cancelled():
     await asyncio.Future()
 
 
-def _mock_running_server(registered_tools=None):
+def _mock_running_server(registered_tools=None, host="localhost", port=3001):
     """Create an MCP server mock whose start task stays alive."""
     mock_server = Mock()
     mock_server.start_server = AsyncMock(side_effect=_run_until_cancelled)
+    # Mimic the real MCPServer: wait_until_bound resolves immediately so the
+    # extension's startup confirmation completes without touching uvicorn.
+    mock_server.wait_until_bound = AsyncMock(return_value=None)
     mock_server._registered_tools = [] if registered_tools is None else registered_tools
+    mock_server.host = host
+    mock_server.port = port
     return mock_server
 
 
@@ -30,7 +53,7 @@ class TestMCPExtensionApp:
         extension = MCPExtensionApp()
 
         assert extension.name == "jupyter_server_mcp"
-        assert extension.mcp_port == 3001
+        assert extension.mcp_port == 0
         assert extension.mcp_name == "Jupyter MCP Server"
 
     def test_extension_trait_configuration(self):
@@ -120,6 +143,9 @@ class TestMCPExtensionLifecycle:
             mock_server.start_server = AsyncMock(
                 side_effect=RuntimeError("Port 3001 is already in use")
             )
+            # If start_server raises, the task should finish first; the bound
+            # waiter should never resolve on its own.
+            mock_server.wait_until_bound = AsyncMock(side_effect=_run_until_cancelled)
             mock_server._registered_tools = []
             mock_mcp_class.return_value = mock_server
 
@@ -374,6 +400,8 @@ class TestExtensionWithTools:
         extension.mcp_port = 3089
         extension.mcp_name = "Test Server With Tools"
         extension.mcp_tools = ["os:getcwd", "math:sqrt"]
+        # Isolate this test from any real entrypoints installed in the env.
+        extension.use_tool_discovery = False
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = _mock_running_server({"getcwd": {}, "sqrt": {}})
@@ -399,6 +427,7 @@ class TestExtensionWithTools:
         extension = MCPExtensionApp()
         extension.mcp_port = 3088
         extension.mcp_tools = []
+        extension.use_tool_discovery = False
 
         with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
             mock_server = _mock_running_server({})
@@ -511,3 +540,273 @@ class TestEntrypointDiscovery:
                 extension._confirm_mcp_server_started.assert_awaited_once()
 
                 await extension.stop_extension()
+
+
+class TestRuntimeInfoPublishing:
+    """Test the runtime info file produced by the extension."""
+
+    @pytest.fixture
+    def runtime_dir(self, tmp_path, monkeypatch):
+        """Redirect ``jupyter_runtime_dir`` so tests do not touch the user's dir."""
+        monkeypatch.setattr(
+            "jupyter_server_mcp.extension.jupyter_runtime_dir",
+            lambda: str(tmp_path),
+        )
+        return tmp_path
+
+    @pytest.mark.asyncio
+    async def test_info_file_written_on_startup_and_removed_on_stop(self, runtime_dir):
+        """Startup writes the info file; shutdown removes it."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3080
+        extension.mcp_name = "Startup Test"
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = _mock_running_server(port=3080)
+            mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
+
+            await extension.start_extension()
+
+            info_path = runtime.info_file_path(runtime_dir, os.getpid())
+            assert info_path.exists(), "info file should be written on startup"
+
+            data = json.loads(info_path.read_text())
+            assert data["pid"] == os.getpid()
+            assert data["port"] == 3080
+            assert data["url"] == "http://localhost:3080/mcp"
+            assert data["name"] == "Startup Test"
+            assert data["root_dir"]  # populated from serverapp or cwd
+
+            await extension.stop_extension()
+
+            assert not info_path.exists(), "info file should be removed on stop"
+
+    @pytest.mark.asyncio
+    async def test_info_file_cleaned_up_on_startup_failure(self, runtime_dir):
+        """When startup fails after the info file is written, clean it up."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3081
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = _mock_running_server(port=3081)
+            mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
+
+            # Force a failure after the info file would be written.
+            with (
+                patch.object(
+                    extension,
+                    "_publish_runtime_info",
+                    side_effect=RuntimeError("boom"),
+                ),
+                pytest.raises(RuntimeError, match="boom"),
+            ):
+                await extension.start_extension()
+
+        info_path = runtime.info_file_path(runtime_dir, os.getpid())
+        assert not info_path.exists()
+        assert extension.mcp_server_instance is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("runtime_dir")
+    async def test_info_file_publish_is_non_fatal_on_error(self):
+        """If publishing fails, the extension should still start."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3082
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = _mock_running_server(port=3082)
+            mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
+
+            with patch(
+                "jupyter_server_mcp.extension.write_info_file",
+                side_effect=OSError("disk full"),
+            ):
+                await extension.start_extension()
+
+            assert extension.mcp_server_instance is mock_server
+            assert extension._runtime_info_path is None
+
+            await extension.stop_extension()
+
+    @pytest.mark.asyncio
+    async def test_info_file_uses_serverapp_root_dir_when_available(self, runtime_dir):
+        """When a serverapp exposes root_dir, it should be recorded verbatim."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3083
+        extension.serverapp = Mock(root_dir=str(runtime_dir))
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = _mock_running_server(port=3083)
+            mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
+
+            await extension.start_extension()
+
+            info_path = runtime.info_file_path(runtime_dir, os.getpid())
+            data = json.loads(info_path.read_text())
+            assert data["root_dir"] == str(runtime_dir.resolve())
+
+            await extension.stop_extension()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("bind_host", "expected_connect_host"),
+        [
+            ("0.0.0.0", "127.0.0.1"),
+            ("::", "::1"),
+            ("localhost", "localhost"),
+        ],
+    )
+    async def test_info_file_url_rewrites_wildcard_hosts(
+        self, runtime_dir, bind_host, expected_connect_host
+    ):
+        """Wildcard bind hosts must be replaced with a dialable loopback in the URL."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 3084
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            mock_server = _mock_running_server(host=bind_host, port=3084)
+            mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
+
+            await extension.start_extension()
+
+            info_path = runtime.info_file_path(runtime_dir, os.getpid())
+            data = json.loads(info_path.read_text())
+            assert data["host"] == bind_host
+            assert data["url"] == f"http://{expected_connect_host}:3084/mcp"
+
+            await extension.stop_extension()
+
+    def test_detect_root_dir_falls_back_to_cwd_when_serverapp_empty(self, tmp_path):
+        """An empty serverapp.root_dir should fall back to the current directory."""
+        extension = MCPExtensionApp()
+        extension.serverapp = Mock(root_dir="")
+
+        with patch("jupyter_server_mcp.extension.Path.cwd", return_value=tmp_path):
+            assert extension._detect_root_dir() == str(tmp_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_info_file_records_ephemeral_port_chosen_by_os(self, runtime_dir):
+        """When mcp_port is 0, the info file must record the real bound port."""
+        extension = MCPExtensionApp()
+        extension.mcp_port = 0  # request an ephemeral port
+
+        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
+            # Simulate uvicorn binding to port 54321 after startup.
+            mock_server = _mock_running_server(port=54321)
+            mock_mcp_class.return_value = mock_server
+            extension._confirm_mcp_server_started = AsyncMock()
+
+            await extension.start_extension()
+
+            info_path = runtime.info_file_path(runtime_dir, os.getpid())
+            data = json.loads(info_path.read_text())
+            assert data["port"] == 54321
+            assert data["url"] == "http://localhost:54321/mcp"
+
+            await extension.stop_extension()
+
+
+class TestConfirmMCPServerStarted:
+    """Tests for the bind/failure/timeout logic in ``_confirm_mcp_server_started``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_when_wait_until_bound_resolves(self):
+        """Normal path: ``wait_until_bound`` resolves first, no exception."""
+        extension = MCPExtensionApp()
+        extension.mcp_startup_timeout = 1
+
+        mock_server = _mock_running_server()
+        task = asyncio.create_task(_run_until_cancelled())
+        extension.mcp_server_instance = mock_server
+        extension.mcp_server_task = task
+
+        try:
+            await extension._confirm_mcp_server_started()
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_raises_when_server_task_fails_before_bind(self):
+        """If start_server raises before bind, the exception is surfaced."""
+        extension = MCPExtensionApp()
+        extension.mcp_startup_timeout = 1
+
+        mock_server = Mock()
+        mock_server.wait_until_bound = AsyncMock(side_effect=_run_until_cancelled)
+
+        async def failing_start():
+            msg = "bind failed"
+            raise RuntimeError(msg)
+
+        task = asyncio.create_task(failing_start())
+        extension.mcp_server_instance = mock_server
+        extension.mcp_server_task = task
+
+        with pytest.raises(RuntimeError, match="bind failed"):
+            await extension._confirm_mcp_server_started()
+
+    @pytest.mark.asyncio
+    async def test_raises_timeout_when_bind_stalls(self):
+        """If neither bind nor failure happens in time, raise ``TimeoutError``."""
+        extension = MCPExtensionApp()
+        extension.mcp_startup_timeout = 0.05
+
+        mock_server = Mock()
+        mock_server.wait_until_bound = AsyncMock(side_effect=_run_until_cancelled)
+
+        task = asyncio.create_task(_run_until_cancelled())
+        extension.mcp_server_instance = mock_server
+        extension.mcp_server_task = task
+
+        try:
+            with pytest.raises(TimeoutError, match="did not bind"):
+                await extension._confirm_mcp_server_started()
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+
+class TestConsoleScript:
+    """Verify the ``jupyter-server-mcp-proxy`` console script is installed."""
+
+    def test_proxy_entry_point_is_registered(self):
+        """The console script should resolve to ``proxy.main``."""
+        entry_points = importlib_metadata.entry_points()
+        if hasattr(entry_points, "select"):
+            scripts = entry_points.select(group="console_scripts")
+        else:
+            scripts = entry_points.get("console_scripts", [])
+
+        by_name = {ep.name: ep for ep in scripts}
+        ep = by_name.get("jupyter-server-mcp-proxy")
+        assert ep is not None, (
+            "jupyter-server-mcp-proxy console script is not installed"
+        )
+        assert ep.load() is proxy.main
+
+
+class TestConnectHost:
+    """Unit tests for ``_connect_host`` wildcard normalization."""
+
+    @pytest.mark.parametrize(
+        ("bind_host", "expected"),
+        [
+            ("0.0.0.0", "127.0.0.1"),
+            ("", "127.0.0.1"),
+            ("::", "::1"),
+            ("::0", "::1"),
+            ("localhost", "localhost"),
+            ("192.168.1.10", "192.168.1.10"),
+            ("example.com", "example.com"),
+        ],
+    )
+    def test_connect_host_mapping(self, bind_host, expected):
+        assert _connect_host(bind_host) == expected

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from jupyter_server_mcp import proxy, runtime
-from jupyter_server_mcp.extension import MCPExtensionApp, _connect_host
+from jupyter_server_mcp.extension import MCPExtensionApp, _connect_host, _url_host
 from jupyter_server_mcp.mcp_server import MCPServer
 
 
@@ -583,32 +583,6 @@ class TestRuntimeInfoPublishing:
             assert not info_path.exists(), "info file should be removed on stop"
 
     @pytest.mark.asyncio
-    async def test_info_file_cleaned_up_on_startup_failure(self, runtime_dir):
-        """When startup fails after the info file is written, clean it up."""
-        extension = MCPExtensionApp()
-        extension.mcp_port = 3081
-
-        with patch("jupyter_server_mcp.extension.MCPServer") as mock_mcp_class:
-            mock_server = _mock_running_server(port=3081)
-            mock_mcp_class.return_value = mock_server
-            extension._confirm_mcp_server_started = AsyncMock()
-
-            # Force a failure after the info file would be written.
-            with (
-                patch.object(
-                    extension,
-                    "_publish_runtime_info",
-                    side_effect=RuntimeError("boom"),
-                ),
-                pytest.raises(RuntimeError, match="boom"),
-            ):
-                await extension.start_extension()
-
-        info_path = runtime.info_file_path(runtime_dir, os.getpid())
-        assert not info_path.exists()
-        assert extension.mcp_server_instance is None
-
-    @pytest.mark.asyncio
     @pytest.mark.usefixtures("runtime_dir")
     async def test_info_file_publish_is_non_fatal_on_error(self):
         """If publishing fails, the extension should still start."""
@@ -653,15 +627,15 @@ class TestRuntimeInfoPublishing:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("bind_host", "expected_connect_host"),
+        ("bind_host", "expected_url_host"),
         [
             ("0.0.0.0", "127.0.0.1"),
-            ("::", "::1"),
+            ("::", "[::1]"),
             ("localhost", "localhost"),
         ],
     )
     async def test_info_file_url_rewrites_wildcard_hosts(
-        self, runtime_dir, bind_host, expected_connect_host
+        self, runtime_dir, bind_host, expected_url_host
     ):
         """Wildcard bind hosts must be replaced with a dialable loopback in the URL."""
         extension = MCPExtensionApp()
@@ -677,7 +651,7 @@ class TestRuntimeInfoPublishing:
             info_path = runtime.info_file_path(runtime_dir, os.getpid())
             data = json.loads(info_path.read_text())
             assert data["host"] == bind_host
-            assert data["url"] == f"http://{expected_connect_host}:3084/mcp"
+            assert data["url"] == f"http://{expected_url_host}:3084/mcp"
 
             await extension.stop_extension()
 
@@ -810,3 +784,16 @@ class TestConnectHost:
     )
     def test_connect_host_mapping(self, bind_host, expected):
         assert _connect_host(bind_host) == expected
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("127.0.0.1", "127.0.0.1"),
+            ("localhost", "localhost"),
+            ("::1", "[::1]"),
+            ("2001:db8::1", "[2001:db8::1]"),
+            ("[::1]", "[::1]"),
+        ],
+    )
+    def test_url_host_formats_ipv6_literals(self, host, expected):
+        assert _url_host(host) == expected

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -73,7 +73,7 @@ class TestMCPServer:
         server = MCPServer()
 
         assert server.name == "Jupyter MCP Server"
-        assert server.port == 0
+        assert server.port == 3001
         assert server.host == "localhost"
         assert server.mcp is not None
         assert len(server._registered_tools) == 0
@@ -413,7 +413,7 @@ class TestMCPServerDirect:
 
         assert isinstance(server, MCPServer)
         assert server.name == "Jupyter MCP Server"
-        assert server.port == 0
+        assert server.port == 3001
 
     def test_create_server_with_params(self):
         """Test creating server with custom parameters."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,9 +1,11 @@
 """Test the simplified MCP server functionality."""
 
 import asyncio
+import contextlib
 import errno
 import signal
 import socket
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -71,7 +73,7 @@ class TestMCPServer:
         server = MCPServer()
 
         assert server.name == "Jupyter MCP Server"
-        assert server.port == 3001
+        assert server.port == 0
         assert server.host == "localhost"
         assert server.mcp is not None
         assert len(server._registered_tools) == 0
@@ -411,7 +413,7 @@ class TestMCPServerDirect:
 
         assert isinstance(server, MCPServer)
         assert server.name == "Jupyter MCP Server"
-        assert server.port == 3001
+        assert server.port == 0
 
     def test_create_server_with_params(self):
         """Test creating server with custom parameters."""
@@ -447,6 +449,78 @@ class TestMCPServerIntegration:
         assert server._registered_tools["simple_function"]["is_async"] is False
         assert server._registered_tools["async_function"]["is_async"] is True
         assert server._registered_tools["printer"]["is_async"] is False
+
+
+class TestBoundPortCapture:
+    """Unit tests for the bound-port capture hook."""
+
+    def test_capture_bound_port_updates_port_and_event(self):
+        """Simulate uvicorn completing startup and verify port + event."""
+
+        class _FakeSocket:
+            def getsockname(self):
+                return ("127.0.0.1", 55555)
+
+        fake_uvicorn = SimpleNamespace(
+            servers=[SimpleNamespace(sockets=[_FakeSocket()])]
+        )
+
+        server = MCPServer(port=0)
+        assert server.port == 0
+        assert not server._bound_event.is_set()
+
+        server._capture_bound_port(fake_uvicorn)
+
+        assert server.port == 55555
+        assert server._bound_event.is_set()
+
+    def test_capture_bound_port_no_servers_still_signals(self):
+        """Even if uvicorn has no listening sockets, the event must fire."""
+        fake_uvicorn = SimpleNamespace(servers=[])
+
+        server = MCPServer(port=1234)
+        server._capture_bound_port(fake_uvicorn)
+
+        # Port left alone — but waiters are released.
+        assert server.port == 1234
+        assert server._bound_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_wait_until_bound_respects_timeout(self):
+        """``wait_until_bound`` should raise ``TimeoutError`` if not set in time."""
+        server = MCPServer()
+        with pytest.raises(asyncio.TimeoutError):
+            await server.wait_until_bound(timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_wait_until_bound_returns_once_set(self):
+        """Once the capture hook fires, waiters resolve immediately."""
+        server = MCPServer()
+        server._bound_event.set()
+        # Should return promptly without raising.
+        await asyncio.wait_for(server.wait_until_bound(), timeout=0.5)
+
+
+class TestEphemeralPortIntegration:
+    """Exercise the full ``start_server`` path with an OS-assigned port."""
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_ephemeral_port_is_captured_and_reachable(self):
+        """``port=0`` should resolve to a real, stable value after binding."""
+        server = MCPServer(port=0)
+        task = asyncio.create_task(server.start_server())
+        try:
+            await server.wait_until_bound(timeout=5.0)
+            assert server.port != 0
+            # Sanity-check the port is actually in use on localhost.
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.settimeout(1.0)
+                probe.connect(("127.0.0.1", server.port))
+        finally:
+            await server.stop_server()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=5.0)
 
 
 class TestJSONArgumentConversion:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -474,31 +474,12 @@ class TestBoundPortCapture:
         assert server.port == 55555
         assert server._bound_event.is_set()
 
-    def test_capture_bound_port_no_servers_still_signals(self):
-        """Even if uvicorn has no listening sockets, the event must fire."""
-        fake_uvicorn = SimpleNamespace(servers=[])
-
-        server = MCPServer(port=1234)
-        server._capture_bound_port(fake_uvicorn)
-
-        # Port left alone — but waiters are released.
-        assert server.port == 1234
-        assert server._bound_event.is_set()
-
     @pytest.mark.asyncio
     async def test_wait_until_bound_respects_timeout(self):
         """``wait_until_bound`` should raise ``TimeoutError`` if not set in time."""
         server = MCPServer()
         with pytest.raises(asyncio.TimeoutError):
             await server.wait_until_bound(timeout=0.05)
-
-    @pytest.mark.asyncio
-    async def test_wait_until_bound_returns_once_set(self):
-        """Once the capture hook fires, waiters resolve immediately."""
-        server = MCPServer()
-        server._bound_event.set()
-        # Should return promptly without raising.
-        await asyncio.wait_for(server.wait_until_bound(), timeout=0.5)
 
 
 class TestEphemeralPortIntegration:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,303 @@
+"""Tests for the stdio proxy discovery and CLI logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from jupyter_server_mcp import proxy, runtime
+
+
+@pytest.fixture
+def isolated_runtime_dir(tmp_path, monkeypatch):
+    """Point discovery at a temporary runtime directory with live pids."""
+    monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
+    monkeypatch.delenv(proxy.ENV_URL, raising=False)
+    return tmp_path
+
+
+def _publish_server(
+    runtime_dir: Path,
+    pid: int,
+    *,
+    root_dir: Path | str,
+    port: int = 3001,
+) -> None:
+    """Write an MCP info file in ``runtime_dir`` for ``pid``."""
+    path = runtime.info_file_path(runtime_dir, pid)
+    runtime.write_info_file(
+        path,
+        {
+            "pid": pid,
+            "host": "localhost",
+            "port": port,
+            "url": f"http://localhost:{port}/mcp",
+            "name": f"Jupyter MCP Server {pid}",
+            "root_dir": str(root_dir),
+        },
+    )
+
+
+class TestResolveUrl:
+    """Tests for ``resolve_url``."""
+
+    def test_explicit_url_wins(self, isolated_runtime_dir):
+        """An explicit URL short-circuits discovery."""
+        url = proxy.resolve_url(
+            url="http://explicit:9999/mcp",
+            runtime_dir=str(isolated_runtime_dir),
+            cwd=str(isolated_runtime_dir),
+        )
+        assert url == "http://explicit:9999/mcp"
+
+    def test_env_var_wins(self, isolated_runtime_dir, monkeypatch):
+        """The env var is honored when no explicit URL is passed."""
+        monkeypatch.setenv(proxy.ENV_URL, "http://env:1234/mcp")
+        url = proxy.resolve_url(
+            runtime_dir=str(isolated_runtime_dir),
+            cwd=str(isolated_runtime_dir),
+        )
+        assert url == "http://env:1234/mcp"
+
+    def test_single_server_discovery(self, isolated_runtime_dir):
+        """A single running server is selected automatically."""
+        _publish_server(isolated_runtime_dir, 101, root_dir=isolated_runtime_dir)
+
+        url = proxy.resolve_url(
+            runtime_dir=str(isolated_runtime_dir),
+            cwd=str(isolated_runtime_dir),
+        )
+
+        assert url == "http://localhost:3001/mcp"
+
+    def test_no_servers_raises(self, isolated_runtime_dir):
+        """An empty runtime directory produces a helpful error."""
+        with pytest.raises(proxy.ProxyError, match="No running Jupyter MCP servers"):
+            proxy.resolve_url(
+                runtime_dir=str(isolated_runtime_dir),
+                cwd=str(isolated_runtime_dir),
+            )
+
+    def test_discovered_url_missing_raises(self, isolated_runtime_dir):
+        """A malformed info dict raises a clear error."""
+        path = runtime.info_file_path(isolated_runtime_dir, 17)
+        runtime.write_info_file(
+            path,
+            {"pid": 17, "host": "localhost", "port": 3001, "root_dir": "/tmp"},
+        )
+
+        with pytest.raises(proxy.ProxyError, match="has no URL"):
+            proxy.resolve_url(
+                runtime_dir=str(isolated_runtime_dir),
+                cwd=str(isolated_runtime_dir),
+            )
+
+    def test_explicit_url_without_scheme_rejected(self, isolated_runtime_dir):
+        """URLs without a scheme are rejected before any discovery happens."""
+        with pytest.raises(proxy.ProxyError, match="absolute http"):
+            proxy.resolve_url(
+                url="localhost:3001/mcp",
+                runtime_dir=str(isolated_runtime_dir),
+                cwd=str(isolated_runtime_dir),
+            )
+
+    def test_explicit_url_with_bad_scheme_rejected(self, isolated_runtime_dir):
+        """Non-http(s) schemes (e.g. file://) are rejected with a scheme error."""
+        with pytest.raises(proxy.ProxyError, match="http or https"):
+            proxy.resolve_url(
+                url="file:///etc/passwd",
+                runtime_dir=str(isolated_runtime_dir),
+                cwd=str(isolated_runtime_dir),
+            )
+
+    def test_env_url_with_bad_scheme_rejected(self, isolated_runtime_dir, monkeypatch):
+        """Validation applies to the env-var form too, not only to ``--url``."""
+        monkeypatch.setenv(proxy.ENV_URL, "ftp://example.com/mcp")
+        with pytest.raises(proxy.ProxyError, match="http or https"):
+            proxy.resolve_url(
+                runtime_dir=str(isolated_runtime_dir),
+                cwd=str(isolated_runtime_dir),
+            )
+
+    def test_cwd_argument_steers_selection(self, isolated_runtime_dir, tmp_path):
+        """Passing ``cwd`` must disambiguate between multiple running servers."""
+        root_a = tmp_path / "alpha"
+        root_b = tmp_path / "beta"
+        root_a.mkdir()
+        root_b.mkdir()
+        _publish_server(isolated_runtime_dir, 201, root_dir=root_a, port=3101)
+        _publish_server(isolated_runtime_dir, 202, root_dir=root_b, port=3102)
+
+        url_a = proxy.resolve_url(
+            runtime_dir=str(isolated_runtime_dir),
+            cwd=str(root_a),
+        )
+        url_b = proxy.resolve_url(
+            runtime_dir=str(isolated_runtime_dir),
+            cwd=str(root_b),
+        )
+
+        assert url_a == "http://localhost:3101/mcp"
+        assert url_b == "http://localhost:3102/mcp"
+
+
+class TestSelectServer:
+    """Tests for the server selection logic."""
+
+    def test_picks_ancestor_with_highest_specificity(self, tmp_path):
+        """Deeper ancestor root_dirs should win over shallower ones."""
+        shallow = tmp_path / "projects"
+        deep = shallow / "alpha"
+        deep.mkdir(parents=True)
+        cwd = deep / "src"
+        cwd.mkdir()
+
+        servers = [
+            {"pid": 1, "url": "http://localhost:3001/mcp", "root_dir": str(shallow)},
+            {"pid": 2, "url": "http://localhost:3002/mcp", "root_dir": str(deep)},
+        ]
+
+        chosen = proxy.select_server(servers, cwd.resolve())
+
+        assert chosen["pid"] == 2
+
+    def test_falls_back_when_no_match_is_ambiguous(self, tmp_path):
+        """If no server contains the cwd, the user must disambiguate."""
+        other_a = tmp_path / "a"
+        other_b = tmp_path / "b"
+        other_a.mkdir()
+        other_b.mkdir()
+        cwd = tmp_path / "c"
+        cwd.mkdir()
+
+        servers = [
+            {"pid": 1, "url": "http://localhost:3001/mcp", "root_dir": str(other_a)},
+            {"pid": 2, "url": "http://localhost:3002/mcp", "root_dir": str(other_b)},
+        ]
+
+        with pytest.raises(proxy.ProxyError, match="Multiple Jupyter MCP servers"):
+            proxy.select_server(servers, cwd.resolve())
+
+    def test_ambiguous_same_root_dir(self, tmp_path):
+        """Two servers with the same root_dir produce a disambiguation error."""
+        root = tmp_path / "shared"
+        root.mkdir()
+
+        servers = [
+            {"pid": 1, "url": "http://localhost:3001/mcp", "root_dir": str(root)},
+            {"pid": 2, "url": "http://localhost:3002/mcp", "root_dir": str(root)},
+        ]
+
+        with pytest.raises(proxy.ProxyError, match="Multiple Jupyter MCP servers"):
+            proxy.select_server(servers, root.resolve())
+
+    def test_single_server_returned_regardless_of_cwd(self, tmp_path):
+        """With only one candidate, return it even if cwd is unrelated."""
+        unrelated = tmp_path / "unrelated"
+        unrelated.mkdir()
+
+        servers = [
+            {"pid": 1, "url": "http://localhost:3001/mcp", "root_dir": str(tmp_path)},
+        ]
+
+        assert proxy.select_server(servers, unrelated.resolve())["pid"] == 1
+
+
+class TestMatchScore:
+    """Unit tests for ``_match_score``."""
+
+    @pytest.mark.parametrize("bad_root", [None, "", 42, []])
+    def test_invalid_root_types_return_none(self, bad_root, tmp_path):
+        assert proxy._match_score(bad_root, tmp_path) is None
+
+    def test_unresolvable_root_returns_none(self, tmp_path, monkeypatch):
+        """If ``Path.resolve`` raises OSError, we must not score that server."""
+
+        original_resolve = Path.resolve
+
+        def raise_os_error(self, *args, **kwargs):  # noqa: ARG001
+            msg = "path loop"
+            raise OSError(msg)
+
+        monkeypatch.setattr(Path, "resolve", raise_os_error)
+        try:
+            assert proxy._match_score("/some/path", tmp_path) is None
+        finally:
+            monkeypatch.setattr(Path, "resolve", original_resolve)
+
+    def test_descendant_cwd_scores_by_parts(self, tmp_path):
+        """The score should be the number of parts in the resolved root path."""
+        root = tmp_path / "projects" / "alpha"
+        root.mkdir(parents=True)
+        cwd = root / "src"
+        cwd.mkdir()
+
+        score = proxy._match_score(str(root), cwd.resolve())
+
+        assert score == len(root.resolve().parts)
+
+    def test_unrelated_cwd_returns_none(self, tmp_path):
+        root = tmp_path / "projects"
+        other = tmp_path / "elsewhere"
+        root.mkdir()
+        other.mkdir()
+
+        assert proxy._match_score(str(root), other.resolve()) is None
+
+
+class TestMainCLI:
+    """Tests for the ``main`` CLI entry point."""
+
+    def test_main_exits_cleanly_on_proxy_error(
+        self, isolated_runtime_dir, capsys, monkeypatch
+    ):
+        """Discovery failures produce an error message and non-zero exit."""
+        monkeypatch.chdir(isolated_runtime_dir)
+        exit_code = proxy.main([])
+
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert "No running Jupyter MCP servers" in captured.err
+
+    def test_main_connects_with_explicit_url(self, monkeypatch):
+        """An explicit URL should trigger ``run_proxy`` without discovery."""
+        calls = []
+
+        async def fake_run_proxy(url):
+            calls.append(url)
+
+        monkeypatch.setattr(proxy, "run_proxy", fake_run_proxy)
+
+        assert proxy.main(["--url", "http://explicit:1/mcp"]) == 0
+        assert calls == ["http://explicit:1/mcp"]
+
+    def test_main_treats_keyboard_interrupt_as_success(self, monkeypatch):
+        """KeyboardInterrupt while proxying should be a clean shutdown."""
+
+        async def raise_kbi(_url):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(proxy, "run_proxy", raise_kbi)
+
+        assert proxy.main(["--url", "http://x/mcp"]) == 0
+
+
+class TestRunProxy:
+    """Test that ``run_proxy`` configures FastMCP correctly."""
+
+    @pytest.mark.asyncio
+    async def test_run_proxy_uses_stdio_transport(self):
+        """``run_proxy`` should forward the URL and pick the stdio transport."""
+        fake_proxy = AsyncMock()
+
+        with patch(
+            "jupyter_server_mcp.proxy.create_proxy", return_value=fake_proxy
+        ) as create:
+            await proxy.run_proxy("http://localhost:3001/mcp")
+
+        create.assert_called_once_with("http://localhost:3001/mcp")
+        fake_proxy.run_async.assert_awaited_once_with(
+            transport="stdio", show_banner=False
+        )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -94,29 +94,27 @@ class TestResolveUrl:
                 cwd=str(isolated_runtime_dir),
             )
 
-    def test_explicit_url_without_scheme_rejected(self, isolated_runtime_dir):
-        """URLs without a scheme are rejected before any discovery happens."""
-        with pytest.raises(proxy.ProxyError, match="absolute http"):
-            proxy.resolve_url(
-                url="localhost:3001/mcp",
-                runtime_dir=str(isolated_runtime_dir),
-                cwd=str(isolated_runtime_dir),
-            )
+    @pytest.mark.parametrize(
+        ("source", "value", "match"),
+        [
+            ("arg", "localhost:3001/mcp", "absolute http"),
+            ("arg", "file:///etc/passwd", "http or https"),
+            ("env", "ftp://example.com/mcp", "http or https"),
+        ],
+    )
+    def test_invalid_urls_are_rejected(
+        self, isolated_runtime_dir, monkeypatch, source, value, match
+    ):
+        """Explicit and env-var URLs must be absolute http(s) URLs."""
+        if source == "env":
+            monkeypatch.setenv(proxy.ENV_URL, value)
+            url = None
+        else:
+            url = value
 
-    def test_explicit_url_with_bad_scheme_rejected(self, isolated_runtime_dir):
-        """Non-http(s) schemes (e.g. file://) are rejected with a scheme error."""
-        with pytest.raises(proxy.ProxyError, match="http or https"):
+        with pytest.raises(proxy.ProxyError, match=match):
             proxy.resolve_url(
-                url="file:///etc/passwd",
-                runtime_dir=str(isolated_runtime_dir),
-                cwd=str(isolated_runtime_dir),
-            )
-
-    def test_env_url_with_bad_scheme_rejected(self, isolated_runtime_dir, monkeypatch):
-        """Validation applies to the env-var form too, not only to ``--url``."""
-        monkeypatch.setenv(proxy.ENV_URL, "ftp://example.com/mcp")
-        with pytest.raises(proxy.ProxyError, match="http or https"):
-            proxy.resolve_url(
+                url=url,
                 runtime_dir=str(isolated_runtime_dir),
                 cwd=str(isolated_runtime_dir),
             )
@@ -203,48 +201,6 @@ class TestSelectServer:
         ]
 
         assert proxy.select_server(servers, unrelated.resolve())["pid"] == 1
-
-
-class TestMatchScore:
-    """Unit tests for ``_match_score``."""
-
-    @pytest.mark.parametrize("bad_root", [None, "", 42, []])
-    def test_invalid_root_types_return_none(self, bad_root, tmp_path):
-        assert proxy._match_score(bad_root, tmp_path) is None
-
-    def test_unresolvable_root_returns_none(self, tmp_path, monkeypatch):
-        """If ``Path.resolve`` raises OSError, we must not score that server."""
-
-        original_resolve = Path.resolve
-
-        def raise_os_error(self, *args, **kwargs):  # noqa: ARG001
-            msg = "path loop"
-            raise OSError(msg)
-
-        monkeypatch.setattr(Path, "resolve", raise_os_error)
-        try:
-            assert proxy._match_score("/some/path", tmp_path) is None
-        finally:
-            monkeypatch.setattr(Path, "resolve", original_resolve)
-
-    def test_descendant_cwd_scores_by_parts(self, tmp_path):
-        """The score should be the number of parts in the resolved root path."""
-        root = tmp_path / "projects" / "alpha"
-        root.mkdir(parents=True)
-        cwd = root / "src"
-        cwd.mkdir()
-
-        score = proxy._match_score(str(root), cwd.resolve())
-
-        assert score == len(root.resolve().parts)
-
-    def test_unrelated_cwd_returns_none(self, tmp_path):
-        root = tmp_path / "projects"
-        other = tmp_path / "elsewhere"
-        root.mkdir()
-        other.mkdir()
-
-        assert proxy._match_score(str(root), other.resolve()) is None
 
 
 class TestMainCLI:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,134 @@
+"""Tests for the MCP runtime info file helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from jupyter_server_mcp import runtime
+
+
+def _write_info(runtime_dir: Path, pid: int, overrides: dict | None = None) -> Path:
+    """Write a minimal info file for ``pid`` in ``runtime_dir``."""
+    path = runtime.info_file_path(runtime_dir, pid)
+    payload = {
+        "pid": pid,
+        "host": "localhost",
+        "port": 3001,
+        "url": f"http://localhost:3001/mcp/{pid}",
+        "name": "Jupyter MCP Server",
+        "root_dir": str(runtime_dir),
+    }
+    if overrides:
+        payload.update(overrides)
+    runtime.write_info_file(path, payload)
+    return path
+
+
+def test_info_file_path_format(tmp_path):
+    """Info files should follow the jpserver-mcp-<pid>.json pattern."""
+    path = runtime.info_file_path(tmp_path, 4242)
+
+    assert path.parent == tmp_path
+    assert path.name == "jpserver-mcp-4242.json"
+
+
+def test_write_info_file_is_atomic_and_readable(tmp_path):
+    """Writing should round-trip the payload and not leave .tmp files behind."""
+    path = tmp_path / "jpserver-mcp-1.json"
+    payload = {"pid": 1, "port": 3001, "url": "http://localhost:3001/mcp"}
+
+    runtime.write_info_file(path, payload)
+
+    assert path.exists()
+    assert json.loads(path.read_text()) == payload
+    leftovers = [entry.name for entry in tmp_path.iterdir() if entry.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_write_info_file_creates_parent_directory(tmp_path):
+    """``write_info_file`` should create missing parent directories."""
+    path = tmp_path / "nested" / "jpserver-mcp-9.json"
+
+    runtime.write_info_file(path, {"pid": 9})
+
+    assert path.exists()
+
+
+def test_remove_info_file_missing_is_noop(tmp_path):
+    """Removing a non-existent info file should not raise."""
+    runtime.remove_info_file(tmp_path / "missing.json")
+
+
+def test_list_running_mcp_servers_empty_dir(tmp_path):
+    """An empty runtime directory yields no servers."""
+    assert list(runtime.list_running_mcp_servers(tmp_path)) == []
+
+
+def test_list_running_mcp_servers_missing_dir(tmp_path):
+    """A missing runtime directory is handled gracefully."""
+    missing = tmp_path / "does-not-exist"
+    assert list(runtime.list_running_mcp_servers(missing)) == []
+
+
+def test_list_running_mcp_servers_ignores_unrelated_files(tmp_path, monkeypatch):
+    """Only ``jpserver-mcp-*.json`` files should be considered."""
+    monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
+    _write_info(tmp_path, 1)
+    (tmp_path / "jpserver-42.json").write_text(json.dumps({"pid": 42}))
+    (tmp_path / "random.json").write_text(json.dumps({"pid": 1}))
+
+    servers = list(runtime.list_running_mcp_servers(tmp_path))
+
+    assert [s["pid"] for s in servers] == [1]
+
+
+def test_list_running_mcp_servers_skips_dead_and_cleans_up(tmp_path, monkeypatch):
+    """Info files for dead PIDs should be skipped and deleted."""
+    live_path = _write_info(tmp_path, 100)
+    dead_path = _write_info(tmp_path, 999)
+
+    monkeypatch.setattr(runtime, "check_pid", lambda pid: pid == 100)
+
+    servers = list(runtime.list_running_mcp_servers(tmp_path))
+
+    assert [s["pid"] for s in servers] == [100]
+    assert live_path.exists()
+    assert not dead_path.exists(), "stale info file should have been cleaned up"
+
+
+def test_list_running_mcp_servers_skips_invalid_json(tmp_path, monkeypatch):
+    """Malformed files should be skipped without crashing the iterator."""
+    monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
+    _write_info(tmp_path, 7)
+    bad = tmp_path / "jpserver-mcp-99.json"
+    bad.write_text("not json")
+
+    servers = list(runtime.list_running_mcp_servers(tmp_path))
+
+    assert [s["pid"] for s in servers] == [7]
+    # Malformed files stay on disk so a later rewrite can succeed.
+    assert bad.exists()
+
+
+def test_list_running_mcp_servers_skips_missing_pid(tmp_path, monkeypatch):
+    """Entries without a numeric pid should be dropped."""
+    monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
+    path = runtime.info_file_path(tmp_path, 1)
+    runtime.write_info_file(path, {"url": "http://localhost:3001/mcp"})
+
+    servers = list(runtime.list_running_mcp_servers(tmp_path))
+
+    assert servers == []
+
+
+@pytest.mark.parametrize("pid_value", ["nope", None, 1.5])
+def test_list_running_mcp_servers_rejects_non_int_pid(tmp_path, monkeypatch, pid_value):
+    """Only integer pids should be accepted."""
+    monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
+    path = runtime.info_file_path(tmp_path, 1)
+    runtime.write_info_file(path, {"pid": pid_value})
+
+    assert list(runtime.list_running_mcp_servers(tmp_path)) == []

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -35,26 +35,19 @@ def test_info_file_path_format(tmp_path):
     assert path.name == "jpserver-mcp-4242.json"
 
 
-def test_write_info_file_is_atomic_and_readable(tmp_path):
-    """Writing should round-trip the payload and not leave .tmp files behind."""
-    path = tmp_path / "jpserver-mcp-1.json"
+def test_write_info_file_creates_parent_and_is_readable(tmp_path):
+    """Writing should create parents, round-trip JSON, and not leave temp files."""
+    path = tmp_path / "nested" / "jpserver-mcp-1.json"
     payload = {"pid": 1, "port": 3001, "url": "http://localhost:3001/mcp"}
 
     runtime.write_info_file(path, payload)
 
     assert path.exists()
     assert json.loads(path.read_text()) == payload
-    leftovers = [entry.name for entry in tmp_path.iterdir() if entry.suffix == ".tmp"]
+    leftovers = [
+        entry.name for entry in path.parent.iterdir() if entry.suffix == ".tmp"
+    ]
     assert leftovers == []
-
-
-def test_write_info_file_creates_parent_directory(tmp_path):
-    """``write_info_file`` should create missing parent directories."""
-    path = tmp_path / "nested" / "jpserver-mcp-9.json"
-
-    runtime.write_info_file(path, {"pid": 9})
-
-    assert path.exists()
 
 
 def test_remove_info_file_missing_is_noop(tmp_path):
@@ -62,15 +55,14 @@ def test_remove_info_file_missing_is_noop(tmp_path):
     runtime.remove_info_file(tmp_path / "missing.json")
 
 
-def test_list_running_mcp_servers_empty_dir(tmp_path):
-    """An empty runtime directory yields no servers."""
-    assert list(runtime.list_running_mcp_servers(tmp_path)) == []
+@pytest.mark.parametrize("exists", [True, False])
+def test_list_running_mcp_servers_empty_or_missing_dir(tmp_path, exists):
+    """Empty or missing runtime directories yield no servers."""
+    directory = tmp_path / "runtime"
+    if exists:
+        directory.mkdir()
 
-
-def test_list_running_mcp_servers_missing_dir(tmp_path):
-    """A missing runtime directory is handled gracefully."""
-    missing = tmp_path / "does-not-exist"
-    assert list(runtime.list_running_mcp_servers(missing)) == []
+    assert list(runtime.list_running_mcp_servers(directory)) == []
 
 
 def test_list_running_mcp_servers_ignores_unrelated_files(tmp_path, monkeypatch):
@@ -113,22 +105,21 @@ def test_list_running_mcp_servers_skips_invalid_json(tmp_path, monkeypatch):
     assert bad.exists()
 
 
-def test_list_running_mcp_servers_skips_missing_pid(tmp_path, monkeypatch):
-    """Entries without a numeric pid should be dropped."""
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"url": "http://localhost:3001/mcp"},
+        {"pid": "nope"},
+        {"pid": None},
+        {"pid": 1.5},
+    ],
+)
+def test_list_running_mcp_servers_rejects_missing_or_non_int_pid(
+    tmp_path, monkeypatch, payload
+):
+    """Only entries with integer pids should be accepted."""
     monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
     path = runtime.info_file_path(tmp_path, 1)
-    runtime.write_info_file(path, {"url": "http://localhost:3001/mcp"})
-
-    servers = list(runtime.list_running_mcp_servers(tmp_path))
-
-    assert servers == []
-
-
-@pytest.mark.parametrize("pid_value", ["nope", None, 1.5])
-def test_list_running_mcp_servers_rejects_non_int_pid(tmp_path, monkeypatch, pid_value):
-    """Only integer pids should be accepted."""
-    monkeypatch.setattr(runtime, "check_pid", lambda _pid: True)
-    path = runtime.info_file_path(tmp_path, 1)
-    runtime.write_info_file(path, {"pid": pid_value})
+    runtime.write_info_file(path, payload)
 
     assert list(runtime.list_running_mcp_servers(tmp_path)) == []


### PR DESCRIPTION
Fixes https://github.com/jupyter-ai-contrib/jupyter-server-mcp/issues/21

- [x] New `jupyter-server-mcp-proxy` console script (also runnable as `python -m jupyter_server_mcp.proxy` or via `uvx`) bridges stdio to the running Jupyter MCP server.
- [x] Keep the default 3001 port but allow for dynamic port with `mcp_port = 0`
- [x] README documents both the `uvx` and `python -m` launcher forms
