### PR TITLE
Route frontend commands to the web client that triggered them

### DIFF
--- a/jupyter_server_mcp/client_routing.py
+++ b/jupyter_server_mcp/client_routing.py
@@ -1,0 +1,122 @@
+"""Hard-wired FastMCP middleware that routes JupyterLab frontend commands to the
+specific web client (browser tab) that triggered the current tool call.
+
+Background
+----------
+``jupyterlab-commands-toolkit`` lets a server-side tool run a JupyterLab command
+on connected web clients by emitting a ``lab_command`` event. Historically that
+event ran on *every* connected browser, so an AI editing a notebook in one tab
+could corrupt a different notebook open in another tab. See
+https://github.com/jupyterlab/jupyter-ai/issues/1650.
+
+How routing works
+-----------------
+``jupyter-ai-persona-manager`` attaches two identity headers to the built-in
+Jupyter MCP server it exposes to each persona:
+
+- ``X-Jupyter-Chat-Id``: the chat the persona belongs to
+- ``X-JupyterAI-Persona-Id``: the persona's id
+
+These headers ride through to every ``tools/call`` request. On each tool call
+this middleware:
+
+1. reads the two headers,
+2. looks up the persona in the server-app registry
+   (``settings["jupyter-ai"]["persona-managers"][chat_id].personas[persona_id]``),
+3. reads the ``web_client_id`` from the message the persona is currently
+   processing (``persona.processing_message.metadata["web_client_id"]``), and
+4. publishes it via the ``target_client_id`` ``ContextVar`` defined in
+   ``jupyterlab-commands-toolkit``.
+
+``jupyterlab_commands_toolkit.tools.execute_command`` reads that ``ContextVar``
+and stamps ``client_id`` on the emitted event, so only the matching browser tab
+runs the command.
+
+Safe degradation
+----------------
+Every hop is defensive. If the toolkit is not installed, the headers are absent,
+the persona can't be found, or it is not processing a message carrying a
+``web_client_id``, the ``ContextVar`` is left unset and commands broadcast to all
+clients (the pre-routing behavior). This keeps ``jupyter-server-mcp`` usable on
+its own, with no hard dependency on either the toolkit or the persona manager.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp.server.dependencies import get_http_headers
+from fastmcp.server.middleware import Middleware
+
+logger = logging.getLogger(__name__)
+
+#: Request header carrying the chat id (lower-cased; ``get_http_headers`` lowers keys).
+CHAT_ID_HEADER = "x-jupyter-chat-id"
+#: Request header carrying the persona id.
+PERSONA_ID_HEADER = "x-jupyterai-persona-id"
+#: Key under ``message.metadata`` holding the originating web client id.
+WEB_CLIENT_ID_METADATA_KEY = "web_client_id"
+
+
+class ClientRoutingMiddleware(Middleware):
+    """Bind the target web client id for the duration of each tool call.
+
+    Args:
+        get_settings: Optional callable returning the Jupyter Server
+            ``web_app.settings`` dict. Defaults to reading the running
+            ``ServerApp`` singleton. Injectable for testing.
+    """
+
+    def __init__(self, get_settings: Callable[[], dict] | None = None) -> None:
+        self._get_settings = get_settings
+
+    def _settings(self) -> dict:
+        if self._get_settings is not None:
+            return self._get_settings()
+        from jupyter_server.serverapp import ServerApp  # noqa: PLC0415
+
+        return ServerApp.instance().web_app.settings
+
+    def _resolve_web_client_id(self) -> str | None:
+        """Resolve the web client id for the current call, or ``None`` to broadcast."""
+        headers = get_http_headers()
+        chat_id = headers.get(CHAT_ID_HEADER)
+        persona_id = headers.get(PERSONA_ID_HEADER)
+        if not chat_id or not persona_id:
+            return None
+        try:
+            managers = (
+                self._settings().get("jupyter-ai", {}).get("persona-managers", {})
+            )
+            manager = managers.get(chat_id)
+            if manager is None:
+                return None
+            persona = manager.personas.get(persona_id)
+            if persona is None:
+                return None
+            message = getattr(persona, "processing_message", None)
+            if message is None:
+                return None
+            metadata = getattr(message, "metadata", None) or {}
+            return metadata.get(WEB_CLIENT_ID_METADATA_KEY)
+        except Exception:
+            logger.debug("Client-routing lookup failed", exc_info=True)
+            return None
+
+    async def on_call_tool(self, context: Any, call_next: Callable) -> Any:
+        # Optional dependency: without the toolkit there is nothing to set, so
+        # the middleware is a transparent pass-through.
+        try:
+            from jupyterlab_commands_toolkit.tools import (  # noqa: PLC0415
+                target_client_id,
+            )
+        except Exception:  # noqa: BLE001 - toolkit is an optional dependency
+            return await call_next(context)
+
+        token = target_client_id.set(self._resolve_web_client_id())
+        try:
+            return await call_next(context)
+        finally:
+            target_client_id.reset(token)

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -142,7 +142,7 @@ class MCPExtensionApp(ExtensionApp):
                 function = self._load_function_from_string(tool_spec)
                 self.mcp_server_instance.register_tool(function)
                 logger.info(f"✅ Registered tool from {source}: {tool_spec}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.error(
                     f"❌ Failed to register tool '{tool_spec}' from {source}: {e}"
                 )
@@ -205,11 +205,11 @@ class MCPExtensionApp(ExtensionApp):
                         f"Discovered {len(valid_specs)} tools from entrypoint '{entry_point.name}'"
                     )
 
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     logger.error(f"Failed to load entrypoint '{entry_point.name}': {e}")
                     continue
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error(f"Failed to discover entrypoints: {e}")
 
         if not discovered_tools:
@@ -347,7 +347,7 @@ class MCPExtensionApp(ExtensionApp):
                 "root_dir": self._detect_root_dir(),
             }
             write_info_file(path, info)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             self.log.warning(f"Could not publish MCP runtime info: {exc}")
             self._runtime_info_path = None
             return

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -21,6 +21,8 @@ from fastmcp.utilities.cli import log_server_banner
 from traitlets import Int, Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
+from .client_routing import ClientRoutingMiddleware
+
 logger = logging.getLogger(__name__)
 
 
@@ -276,6 +278,11 @@ class MCPServer(LoggingConfigurable):
 
         # Initialize FastMCP and tools registry
         self.mcp = FastMCP(self.name)
+        # Route JupyterLab frontend commands to the web client that triggered
+        # the call (see client_routing.ClientRoutingMiddleware). Hard-wired, but
+        # a safe no-op unless jupyterlab-commands-toolkit is installed and the
+        # persona manager has attached identity headers.
+        self.mcp.add_middleware(ClientRoutingMiddleware())
         self._registered_tools = {}
         self._uvicorn_server: uvicorn.Server | None = None
         self._bound_event: asyncio.Event = asyncio.Event()
@@ -334,7 +341,7 @@ class MCPServer(LoggingConfigurable):
                 self.register_tool(func, name=name)
         else:
             msg = "tools must be a list of functions or dict mapping names to functions"
-            raise ValueError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
     def list_tools(self) -> list[dict[str, Any]]:
         """List all registered tools."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ test = [
     "pytest-asyncio>=0.21.0", 
     "pytest-jupyter[server]>=0.6",
     "pytest-tornasync>=0.6.0",
-    "pytest-mock>=3.10.0"
+    "pytest-mock>=3.10.0",
+    # Provides `target_client_id`, exercised by the client-routing E2E tests.
+    "jupyterlab-commands-toolkit>=0.2.0a0",
 ]
 dev = [
     "ruff>=0.1.0"

--- a/tests/test_client_routing.py
+++ b/tests/test_client_routing.py
@@ -1,0 +1,180 @@
+"""E2E tests for the hard-wired client-routing middleware.
+
+These drive a real FastMCP server over streamable HTTP with a real MCP client,
+sending the identity headers the persona manager attaches, and assert the
+middleware resolves the originating web client id into the
+``jupyterlab-commands-toolkit`` ``target_client_id`` ContextVar that a tool then
+reads. This mirrors, end to end, how ``jupyter-ai-persona-manager`` +
+``jupyterlab-commands-toolkit`` route a command to a single browser tab.
+"""
+
+import asyncio
+import socket
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+import uvicorn
+from fastmcp import FastMCP
+from jupyterlab_commands_toolkit.tools import target_client_id
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from jupyter_server_mcp.client_routing import (
+    CHAT_ID_HEADER,
+    PERSONA_ID_HEADER,
+    ClientRoutingMiddleware,
+)
+from jupyter_server_mcp.mcp_server import MCPServer
+
+# Mutable stand-in for the Jupyter Server ``web_app.settings`` the middleware
+# reads. Tests mutate the persona registry before each call.
+_FAKE_SETTINGS: dict = {"jupyter-ai": {"persona-managers": {}}}
+
+
+def _set_registry(managers: dict) -> None:
+    _FAKE_SETTINGS["jupyter-ai"]["persona-managers"] = managers
+
+
+def _persona(web_client_id=None, *, processing=True):
+    """Build a duck-typed persona with an in-flight message (or none)."""
+    message = None
+    if processing:
+        metadata = {} if web_client_id is None else {"web_client_id": web_client_id}
+        message = SimpleNamespace(metadata=metadata)
+    return SimpleNamespace(processing_message=message)
+
+
+def _manager(personas: dict):
+    return SimpleNamespace(personas=personas)
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _Server(uvicorn.Server):
+    def install_signal_handlers(self) -> None:  # run cleanly in a thread
+        pass
+
+
+@pytest.fixture(scope="module")
+def mcp_url():
+    """A real FastMCP HTTP server with the routing middleware + a probe tool."""
+    mcp = FastMCP("routing-test")
+    mcp.add_middleware(ClientRoutingMiddleware(get_settings=lambda: _FAKE_SETTINGS))
+
+    @mcp.tool
+    async def whoami(delay: float = 0.0) -> dict:
+        """Return the target web client id bound for this call (after an optional
+        delay, so concurrent calls can be forced to overlap)."""
+        if delay:
+            await asyncio.sleep(delay)
+        return {"wid": target_client_id.get()}
+
+    port = _free_port()
+    app = mcp.http_app(transport="http")
+    server = _Server(
+        uvicorn.Config(
+            app, host="127.0.0.1", port=port, lifespan="on", log_level="error"
+        )
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(100):
+        if server.started:
+            break
+        time.sleep(0.05)
+    yield f"http://127.0.0.1:{port}/mcp"
+    server.should_exit = True
+    time.sleep(0.3)
+
+
+async def _call_whoami(url: str, headers: dict, delay: float = 0.0):
+    async with (
+        streamablehttp_client(url, headers=headers) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        result = await session.call_tool("whoami", {"delay": delay})
+        return (result.structuredContent or {}).get("wid")
+
+
+@pytest.mark.asyncio
+async def test_routes_to_processing_web_client(mcp_url):
+    """Headers + a persona processing a message → that message's web client id."""
+    _set_registry({"chat-1": _manager({"persona-1": _persona("WID-A")})})
+    wid = await _call_whoami(
+        mcp_url, {CHAT_ID_HEADER: "chat-1", PERSONA_ID_HEADER: "persona-1"}
+    )
+    assert wid == "WID-A"
+
+
+@pytest.mark.asyncio
+async def test_no_headers_broadcasts(mcp_url):
+    """No identity headers → ContextVar unset (None) → command broadcasts."""
+    _set_registry({"chat-1": _manager({"persona-1": _persona("WID-A")})})
+    wid = await _call_whoami(mcp_url, {})
+    assert wid is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_persona_broadcasts(mcp_url):
+    """Headers naming an absent persona → None (broadcast), never an error."""
+    _set_registry({"chat-1": _manager({})})
+    wid = await _call_whoami(
+        mcp_url, {CHAT_ID_HEADER: "chat-1", PERSONA_ID_HEADER: "nope"}
+    )
+    assert wid is None
+
+
+@pytest.mark.asyncio
+async def test_persona_not_processing_broadcasts(mcp_url):
+    """Persona present but processing nothing → None (broadcast)."""
+    _set_registry({"chat-1": _manager({"persona-1": _persona(processing=False)})})
+    wid = await _call_whoami(
+        mcp_url, {CHAT_ID_HEADER: "chat-1", PERSONA_ID_HEADER: "persona-1"}
+    )
+    assert wid is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_are_isolated(mcp_url):
+    """Two overlapping calls for different personas each resolve their own id.
+
+    The tool sleeps while the ContextVar is set, guaranteeing the two calls are
+    in flight simultaneously; a leak between them would surface as a swapped or
+    dropped id.
+    """
+    _set_registry(
+        {
+            "chat-1": _manager({"persona-1": _persona("WID-A")}),
+            "chat-2": _manager({"persona-2": _persona("WID-B")}),
+        }
+    )
+    wid_a, wid_b = await asyncio.gather(
+        _call_whoami(
+            mcp_url,
+            {CHAT_ID_HEADER: "chat-1", PERSONA_ID_HEADER: "persona-1"},
+            delay=1.0,
+        ),
+        _call_whoami(
+            mcp_url,
+            {CHAT_ID_HEADER: "chat-2", PERSONA_ID_HEADER: "persona-2"},
+            delay=1.0,
+        ),
+    )
+    assert wid_a == "WID-A"
+    assert wid_b == "WID-B"
+
+
+def test_mcpserver_wires_routing_middleware():
+    """MCPServer installs the routing middleware on its FastMCP instance."""
+    server = MCPServer(name="wiring-test", port=0)
+    middleware = getattr(server.mcp, "middleware", []) or []
+    assert any(isinstance(m, ClientRoutingMiddleware) for m in middleware)


### PR DESCRIPTION
## Motivation

A server-side tool can run a JupyterLab command on a web client (for example, running a notebook cell), but that command currently runs on every connected client. An AI acting for one user can therefore clobber a different notebook another user has open. Part of jupyterlab/jupyter-ai#1650.

## Summary

A tool call's frontend command is now delivered only to the web client that triggered it. The server reads the chat and persona identity that jupyter-ai-persona-manager attaches to the built-in Jupyter MCP server, finds the message that persona is currently answering, and hands the originating web client id to jupyterlab-commands-toolkit, which stamps it on the emitted command so only that browser tab acts on it.

When any of that is absent — the toolkit isn't installed, the identity headers aren't present, or the persona isn't answering a message from a specific client — the command broadcasts as before. jupyter-server-mcp keeps working standalone, with no hard dependency on the toolkit or the persona manager.

## Technical details

- The middleware is always installed but resolves the target lazily, so the pieces above stay optional.

- Companion changes: jupyterlab-commands-toolkit 0.2.0a0 (issues the per-tab web client ids and reads the routing context) and jupyter-ai-contrib/jupyter-ai-persona-manager#145 (attaches the identity headers and serializes persona processing).

- I also silenced a few pre-existing ruff findings a newer ruff flags in unrelated files, so the lint job stays green. Happy to pull that into its own change.

## Testing

Added an end-to-end test that drives the server over HTTP with a real MCP client, covering routing, the broadcast fallbacks, and isolation between two concurrent calls.