### PR TITLE
[0.2.x] Enable Host/Origin protection by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,8 @@ name: Tests
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, 0.2.x ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:

--- a/jupyter_server_mcp/extension.py
+++ b/jupyter_server_mcp/extension.py
@@ -103,7 +103,7 @@ class MCPExtensionApp(ExtensionApp):
                 function = self._load_function_from_string(tool_spec)
                 self.mcp_server_instance.register_tool(function)
                 logger.info(f"✅ Registered tool from {source}: {tool_spec}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.error(
                     f"❌ Failed to register tool '{tool_spec}' from {source}: {e}"
                 )
@@ -166,11 +166,11 @@ class MCPExtensionApp(ExtensionApp):
                         f"Discovered {len(valid_specs)} tools from entrypoint '{entry_point.name}'"
                     )
 
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     logger.error(f"Failed to load entrypoint '{entry_point.name}': {e}")
                     continue
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error(f"Failed to discover entrypoints: {e}")
 
         if not discovered_tools:

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -18,7 +18,8 @@ import uvicorn
 from fastmcp import FastMCP
 from fastmcp import settings as fastmcp_settings
 from fastmcp.utilities.cli import log_server_banner
-from traitlets import Int, Unicode
+from traitlets import Bool, Enum, Int, List, Unicode
+from traitlets import Union as UnionTrait
 from traitlets.config.configurable import LoggingConfigurable
 
 logger = logging.getLogger(__name__)
@@ -251,6 +252,46 @@ class MCPServer(LoggingConfigurable):
         default_value="localhost", help="Host for the MCP server to listen on"
     ).tag(config=True)
 
+    host_origin_protection = UnionTrait(
+        [Bool(), Enum(["auto"])],
+        default_value=True,
+        help=(
+            "Validate the ``Host`` and ``Origin`` headers of incoming requests "
+            "to protect the MCP server against DNS-rebinding and cross-origin "
+            "attacks (the MCP server runs on its own port, outside Jupyter "
+            "Server's token/XSRF protection). "
+            "``True`` (default) always validates; ``'auto'`` validates only "
+            "when bound to a loopback address; ``False`` disables validation "
+            "and is strongly discouraged. The loopback hosts (127.0.0.1, "
+            "localhost, ::1) and the configured bind ``host`` are always "
+            "trusted. Requests with a foreign ``Origin`` are rejected with 403 "
+            "and those with a foreign ``Host`` with 421, before reaching any "
+            "registered tool."
+        ),
+    ).tag(config=True)
+
+    allowed_hosts = List(
+        trait=Unicode(),
+        default_value=[],
+        help=(
+            "Additional ``Host`` header values to accept, beyond the loopback "
+            "defaults (127.0.0.1, localhost, ::1) and the configured bind "
+            "``host``. Set this for reverse-proxy or non-loopback deployments. "
+            "Only used when ``host_origin_protection`` is enabled."
+        ),
+    ).tag(config=True)
+
+    allowed_origins = List(
+        trait=Unicode(),
+        default_value=[],
+        help=(
+            "Additional browser ``Origin`` values to trust, beyond the loopback "
+            "defaults. Set this when the MCP server is legitimately reached "
+            "from a non-loopback web origin. "
+            "Only used when ``host_origin_protection`` is enabled."
+        ),
+    ).tag(config=True)
+
     def __init__(self, **kwargs):
         """Initialize the MCP server.
 
@@ -334,7 +375,12 @@ class MCPServer(LoggingConfigurable):
     async def _run_http_async_without_signals(self, host: str, port: int) -> None:
         """Run FastMCP over HTTP without taking over process signal handlers."""
         transport = "http"
-        app = self.mcp.http_app(transport=transport)
+        app = self.mcp.http_app(
+            transport=transport,
+            host_origin_protection=self.host_origin_protection,
+            allowed_hosts=list(self.allowed_hosts) or None,
+            allowed_origins=list(self.allowed_origins) or None,
+        )
 
         log_server_banner(server=self.mcp)
 

--- a/jupyter_server_mcp/mcp_server.py
+++ b/jupyter_server_mcp/mcp_server.py
@@ -359,7 +359,7 @@ class MCPServer(LoggingConfigurable):
                 self.register_tool(func, name=name)
         else:
             msg = "tools must be a list of functions or dict mapping names to functions"
-            raise ValueError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
     def list_tools(self) -> list[dict[str, Any]]:
         """List all registered tools."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,12 @@ classifiers = [
 
 dependencies = [
     "jupyter_server>=1.6,<3",
-    "fastmcp>=3"
+    # 3.4.3 introduced FastMCP's Host/Origin request guard, but shipped it on
+    # by default and broke HTTP/proxy deployments; 3.4.4 stabilized the guard
+    # (relaxed defaults + restored compatibility). We rely on its
+    # ``host_origin_protection`` / ``allowed_hosts`` / ``allowed_origins``
+    # arguments to ``http_app``.
+    "fastmcp>=3.4.4"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,7 @@
 """Test the simplified MCP server functionality."""
 
 import asyncio
+import contextlib
 import errno
 import signal
 import socket
@@ -447,6 +448,124 @@ class TestMCPServerIntegration:
         assert server._registered_tools["simple_function"]["is_async"] is False
         assert server._registered_tools["async_function"]["is_async"] is True
         assert server._registered_tools["printer"]["is_async"] is False
+
+
+def _free_port() -> int:
+    """Reserve an ephemeral loopback port and return it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+async def _wait_until_accepting(port: int, timeout: float = 10.0) -> None:
+    """Block until the MCP server is accepting connections on ``port``."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.settimeout(0.5)
+                probe.connect(("127.0.0.1", port))
+            return
+        except OSError:
+            await asyncio.sleep(0.05)
+    msg = f"MCP server did not start listening on port {port}"
+    raise TimeoutError(msg)
+
+
+def _raw_http_post(port: int, host_header: str, origin: str | None = None):
+    """Send a crafted HTTP POST to the MCP endpoint and return the status code.
+
+    Uses a raw socket so the ``Host`` header can be set to an arbitrary value
+    (which higher-level clients derive from the URL and will not let us forge).
+    """
+    body = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":'
+        b'{"protocolVersion":"2025-06-18","capabilities":{},'
+        b'"clientInfo":{"name":"t","version":"1"}}}'
+    )
+    lines = [
+        "POST /mcp/ HTTP/1.1",
+        f"Host: {host_header}",
+        "Content-Type: application/json",
+        "Accept: application/json, text/event-stream",
+        f"Content-Length: {len(body)}",
+        "Connection: close",
+    ]
+    if origin is not None:
+        lines.insert(2, f"Origin: {origin}")
+    request = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii") + body
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(5.0)
+        sock.connect(("127.0.0.1", port))
+        sock.sendall(request)
+        status_line = b""
+        while b"\r\n" not in status_line:
+            chunk = sock.recv(256)
+            if not chunk:
+                break
+            status_line += chunk
+    # e.g. b"HTTP/1.1 421 Misdirected Request\r\n..."
+    return int(status_line.split()[1])
+
+
+@pytest.mark.integration
+class TestHostOriginProtection:
+    """Validate the Host/Origin request guard on the MCP server."""
+
+    def test_secure_by_default(self):
+        """Host/Origin protection is enabled with an empty allowlist by default."""
+        server = MCPServer()
+        assert server.host_origin_protection is True
+        assert server.allowed_hosts == []
+        assert server.allowed_origins == []
+
+    @pytest.mark.asyncio
+    async def test_foreign_host_and_origin_are_rejected(self):
+        """Foreign ``Host`` yields 421 and foreign ``Origin`` yields 403.
+
+        Loopback requests (as used by the in-process MCP client) pass through.
+        """
+        port = _free_port()
+        server = MCPServer(port=port)
+        task = asyncio.create_task(server.start_server(host="127.0.0.1"))
+        try:
+            await _wait_until_accepting(port)
+
+            # Legitimate loopback request (no Origin) is not blocked by the guard.
+            legit = await asyncio.to_thread(_raw_http_post, port, f"127.0.0.1:{port}")
+            assert legit not in (403, 421)
+
+            # DNS-rebinding: attacker domain rebinds to 127.0.0.1 -> foreign Host.
+            rebind = await asyncio.to_thread(_raw_http_post, port, "attacker.com")
+            assert rebind == 421
+
+            # Cross-origin: loopback Host but attacker-controlled Origin.
+            cross = await asyncio.to_thread(
+                _raw_http_post, port, f"127.0.0.1:{port}", "http://evil.example"
+            )
+            assert cross == 403
+        finally:
+            await server.stop_server()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_protection_can_be_disabled(self):
+        """Setting ``host_origin_protection=False`` restores unguarded behavior."""
+        port = _free_port()
+        server = MCPServer(port=port, host_origin_protection=False)
+        task = asyncio.create_task(server.start_server(host="127.0.0.1"))
+        try:
+            await _wait_until_accepting(port)
+            # With protection off, a foreign Host is no longer rejected.
+            status = await asyncio.to_thread(_raw_http_post, port, "attacker.com")
+            assert status not in (403, 421)
+        finally:
+            await server.stop_server()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=5.0)
 
 
 class TestJSONArgumentConversion:


### PR DESCRIPTION
Backport to 0.2.x.

Enables FastMCP's Host/Origin request guard by default on the MCP server, which runs on its own port outside Jupyter Server's token/XSRF protection. Loopback hosts and the configured bind host are trusted; new `allowed_hosts` / `allowed_origins` settings extend the allowlist for non-loopback / reverse-proxy deployments.

Floors `fastmcp` at 3.4.4 (where the guard was stabilized). Adds regression tests.