### PR TITLE
Add `fastmcp<4` version ceiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,13 @@ dependencies = [
     # (relaxed defaults + restored compatibility). We rely on its
     # ``host_origin_protection`` / ``allowed_hosts`` / ``allowed_origins``
     # arguments to ``http_app``.
-    "fastmcp>=3.4.4"
+    #
+    # Cap below 4.0: fastmcp 4.0.0 (2026-08-31) is a major with breaking
+    # changes and raises its own mcp floor to >=2.0 (via fastmcp-slim), whereas
+    # 3.4.x pins mcp<2.0. We have not yet verified jupyter-server-mcp against
+    # fastmcp 4.x / mcp 2.x, so hold at 3.x until we do. This also keeps the
+    # transitive mcp SDK on the 1.x API that downstream clients still use.
+    "fastmcp>=3.4.4,<4"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Motivation

fastmcp 4.0 shipped a few days ago (2026-08-31). It's a breaking major, and it raises its own mcp SDK floor to `>=2.0` where 3.4.x pinned `mcp<2`. We depend on `fastmcp>=3.4.4` with no upper bound, so a fresh install now pulls fastmcp 4 + mcp 2 — a stack we haven't validated, and one that breaks downstream MCP clients still on the mcp 1.x API (mcp 2 removed `streamablehttp_client`, among others).

## Summary

Cap the dependency at `fastmcp>=3.4.4,<4` until we validate the 4.x / mcp 2.x stack. This also holds the transitive mcp SDK on 1.x, since 3.4.x pins `mcp<2`.

mcp isn't a direct dependency here (we only reach it through fastmcp), so `fastmcp<4` is the single knob to turn.
